### PR TITLE
ci: redirect comments on closed issues to a fresh issue

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -1,0 +1,34 @@
+name: "Closed Issue Comment"
+
+# Nudge commenters on closed issues toward opening a fresh issue instead —
+# closed threads are easy for maintainers to miss, and a comment there can
+# sit unnoticed indefinitely (see #179 -> #223).
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  redirect:
+    name: Redirect comment on closed issue
+    runs-on: ubuntu-latest
+    # issue_comment also fires for PR comments (PRs are issues under the
+    # hood) — exclude those, and only act when the issue is closed. Skip
+    # the bot's own comment to avoid re-triggering itself.
+    if: >
+      github.event.issue.state == 'closed' &&
+      !github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "This issue is closed. If you're still seeing this, please open a new issue and link back here — closed threads are easy for maintainers to miss.",
+            });


### PR DESCRIPTION
New workflow, triggered on `issue_comment` — filters to comments on **closed** issues (excluding PRs, which also fire this event) and posts a one-time redirect pointing the commenter at opening a fresh issue instead.

Motivated by #179 → #223: a DWD rate-limit report closed as fixed, then a similar report showed up as a brand-new issue rather than a comment on the old one — fine in that direction, but the reverse (someone commenting on the closed #179 instead) would have gone unnoticed indefinitely.

Guards:
- `!github.event.issue.pull_request` — `issue_comment` also fires for PR comments; PRs aren't issues here.
- `github.event.comment.user.type != 'Bot'` — skips the workflow's own comment so it can't re-trigger itself in a loop.

No app code touched; `npm test`/`npm run build` pass as a formality (this doesn't affect them). Validated the YAML parses cleanly; can't fully dry-run an `issue_comment`-triggered workflow without an actual comment on a closed issue post-merge.