### PR TITLE
ci: bump actions/github-script to v9 (node24)

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -23,7 +23,7 @@ jobs:
       !github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot'
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // "Close with comment" fires issue_comment too, with no flag


### PR DESCRIPTION
The run for #229 logged: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/github-script@v7." v9 targets `node24` natively (confirmed via its `action.yml`), resolving the warning at the source instead of relying on GitHub's forced-compatibility shim.