### PR TITLE
docs(templates): overhaul issue templates, auto-check bug reports for a config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,15 +1,14 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: '[BUG] '
 labels: bug
 assignees: ''
 
 ---
 
 <!-- READ THIS FIRST:
-- If you need additional help with this template please refer to https://www.home-assistant.io/help/reporting_issues/
-- Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
+- Make sure you are running the latest version of the card before reporting an issue.
 - Provide as many details as possible. Do not delete any text from this template!
 -->
 
@@ -25,21 +24,43 @@ assignees: ''
 
 **Browser and Operating System:**
 
-**Card Config (click Show Code Editor and copy paste your config, remove a few of the least significant digits of your lat/lon to avoid posting you exact home address):**
-
-<!--
-Provide details about what browser (and version) you are seeing the issue in. And also which operating system this is on. If possible try to replicate the issue in other browsers and include your findings here.
--->
-
 **Description of problem:**
 
+<!-- What's happening, and what did you expect instead? -->
+
+**Screenshots:**
+
 <!--
-Explain what the issue is, and how things should look/behave. If possible provide a screenshot with a description.
+If this is a visual issue (something rendering wrong, misaligned,
+missing, etc.), a screenshot makes it much faster to diagnose — drag an
+image into this box, or paste one from your clipboard. Not needed for
+non-visual issues (e.g. a config option not being respected).
 -->
 
-**Javascript errors shown in the web inspector (if applicable):**
+**Card config:**
+
+<!--
+Home Assistant dashboard -> the card -> pencil/edit icon -> "Show code
+editor" (toggle in the top-right of the card editor) -> copy everything
+and paste it below, between the ```yaml and ``` lines (this is what
+makes it render as a readable code block instead of one long line).
+Please redact your exact location — trimming the last digit or two off
+your latitude/longitude is enough.
+-->
+
+```yaml
 
 ```
+
+**Browser console log (optional):**
+
+<!--
+Only needed if you saw an error, or if a maintainer asks for it. Open
+DevTools (F12, or Cmd+Opt+I on Mac), the Console tab, reproduce the
+issue, then paste anything relevant below.
+-->
+
+```text
 
 ```
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: '[FR] '
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/something_else.md
+++ b/.github/ISSUE_TEMPLATE/something_else.md
@@ -1,0 +1,17 @@
+---
+name: Something else
+about: Doesn't fit Bug report or Feature request
+title: ''
+labels: question
+assignees: ''
+
+---
+
+<!--
+Before you continue: is this actually a bug report or a feature
+request? If so, please go back and use that template instead — it
+asks for the specific details (card config, screenshots, console log,
+etc.) that get bugs fixed and features considered faster.
+
+Still something else? Go ahead and describe it below.
+-->

--- a/.github/workflows/require-yaml-config.yml
+++ b/.github/workflows/require-yaml-config.yml
@@ -1,0 +1,45 @@
+name: "Require YAML Config on Bug Reports"
+
+# The bug report template asks for a ```yaml card config block, but
+# nothing stops someone from leaving it empty. Missing config is one of
+# the most common reasons a bug report stalls waiting on a reply — check
+# for it up front instead.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    name: Check for a card config
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.issue.body ?? '';
+            const match = body.match(/```yaml\r?\n([\s\S]*?)```/);
+            const config = match ? match[1].trim() : '';
+            if (config.length > 0) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "Thanks for the report! This looks like it's missing a card config, which is usually essential for tracking down the cause.",
+                '',
+                'Could you edit your issue and add it under **Card config**? Wrap your YAML in triple backticks so it renders correctly:',
+                '',
+                '```yaml',
+                'type: custom:weather-radar-card',
+                '...(your config)...',
+                '```',
+                '',
+                '(Get it from Home Assistant: edit the card → **Show code editor** (top-right toggle) → copy everything.)',
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Bug report template
- Reorganized to description → screenshots (if visual) → card config → optional console log, matching how issues actually get triaged.
- The card-config section now explains the ` ```yaml ` fencing itself, for people unfamiliar with markdown — previously just said "paste your config" with no formatting guidance.
- `title: '[BUG] '` pre-fills the title box. Not enforced (legacy markdown templates can't lock a title), but nudges toward consistent naming.

## Feature request template
- `title: '[FR] '` pre-fill, same caveat.
- `labels: enhancement` — was unset before, so feature requests weren't auto-labeled at all.

## New: "Something else" template + blank issues disabled
GitHub's "Open a blank issue" option is genuinely blank — no template file backs it, so there's no way to inject a comment/nudge into it. Instead: `config.yml` sets `blank_issues_enabled: false`, and a new `something_else.md` template catches everything that doesn't fit Bug report or Feature request, with a comment nudging the user to double-check those templates first.

## New: auto-check bug reports for a card config
`require-yaml-config.yml` — on `issues: opened`, gated to issues carrying the `bug` label (auto-applied by the template), checks for a filled-in ` ```yaml ` card-config block and comments asking for one if it's empty or absent. Verified the detection regex against empty-template, filled-in, and no-block-at-all cases locally before shipping.

Bot comment text:
> Thanks for the report! This looks like it's missing a card config, which is usually essential for tracking down the cause.
>
> Could you edit your issue and add it under **Card config**? Wrap your YAML in triple backticks so it renders correctly:
>
> ```yaml
> type: custom:weather-radar-card
> ...(your config)...
> ```
>
> (Get it from Home Assistant: edit the card → **Show code editor** (top-right toggle) → copy everything.)