### PR TITLE
fix(security): escape marker color/icon before interpolating into divIcon HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`preload_while_hidden` option** — keep fetching fresh radar and hazard-overlay data (wildfires, NWS alerts, wind) on their normal cadence while the card is hidden, instead of the default full pause. Fixes the "popup card reloads from scratch every time it opens" experience (e.g. inside a Bubble Card pop-up): the card resumes playback instantly from already-warm data instead of a multi-second reload. Animation and canvas rendering stay paused while hidden either way — only the underlying data stays fresh. Opt-in, since it means real network/bandwidth use while the card isn't visible. ([#234](https://github.com/jpettitt/weather-radar-card/issues/234))
 
+### Fixed
+
+- **Marker `color`/`icon` config values are now HTML-escaped before rendering.** A security audit of external-data rendering (NWS alerts, wildfires, lightning — all already consistently escaped) turned up one gap: `markers:` config's `color` and `icon` fields were interpolated unescaped into the marker's inline SVG/`<ha-icon>` HTML. Not externally reachable — it's the dashboard owner's own YAML — but a crafted value in a copy-pasted config could break out of the attribute. Closed with the same `escapeHtml()` helper already used everywhere else.
+
 ## [3.7.3-beta2] - 2026-07-17
 
 > **Beta pre-release.** DWD server-error handling fix. Continues the 3.7.3 beta line — drop-in upgrade from 3.7.3-beta1, no config changes required.

--- a/src/marker-icon.ts
+++ b/src/marker-icon.ts
@@ -1,6 +1,7 @@
 import * as L from 'leaflet';
 import { HomeAssistant } from 'custom-card-helpers';
 import { Marker } from './types';
+import { escapeHtml } from './string-utils';
 
 const ICON_BASE = '/local/community/weather-radar-card/';
 
@@ -78,7 +79,7 @@ export function createMarkerIconForMarker(
   if (iconType === 'default') {
     if (markerCfg.color) {
       return L.divIcon({
-        html: `<svg viewBox="0 0 24 24" width="16" height="16"><path fill="${colour}" d="${HOME_CIRCLE_PATH}"/></svg>`,
+        html: `<svg viewBox="0 0 24 24" width="16" height="16"><path fill="${escapeHtml(colour)}" d="${HOME_CIRCLE_PATH}"/></svg>`,
         iconSize: [16, 16],
         className: 'marker-mdi-icon',
       });
@@ -98,7 +99,7 @@ export function createMarkerIconForMarker(
     // <ha-icon> is registered globally by HA frontend and resolves any MDI
     // icon from HA's bundled database — no need to ship our own path table.
     return L.divIcon({
-      html: `<ha-icon icon="${iconType}" style="--mdc-icon-size: 24px; color: ${colour};"></ha-icon>`,
+      html: `<ha-icon icon="${escapeHtml(iconType)}" style="--mdc-icon-size: 24px; color: ${escapeHtml(colour)};"></ha-icon>`,
       iconSize: [24, 24],
       className: 'marker-mdi-icon',
     });

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -102,6 +102,7 @@ import { NwsAlertsLayer } from './nws-alerts-layer';
 import { LightningLayer } from './lightning-layer';
 import { isBlitzortungLoaded } from './lightning-helpers';
 import { getRegionWarnings } from './region-warning';
+import { escapeHtml } from './string-utils';
 import { resolveCardLayout, isValidCssSize } from './card-layout';
 import { PopupPanRestore } from './popup-pan-restore';
 import { isOnlyKeysChanged } from './config-diff';
@@ -959,8 +960,8 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       const defaultColor = isDark ? '#EEEEEE' : '#333333';
       const iconColor = repCfg?.color ?? defaultColor;
       const iconHtml = repIcon?.startsWith('mdi:')
-        ? `<ha-icon icon="${repIcon}" style="--mdc-icon-size:${iconSize}px;color:${iconColor};display:block"></ha-icon>`
-        : `<svg viewBox="0 0 24 24" width="${iconSize}" height="${iconSize}"><path fill="${iconColor}" d="${HOME_PATH}"/></svg>`;
+        ? `<ha-icon icon="${escapeHtml(repIcon)}" style="--mdc-icon-size:${iconSize}px;color:${escapeHtml(iconColor)};display:block"></ha-icon>`
+        : `<svg viewBox="0 0 24 24" width="${iconSize}" height="${iconSize}"><path fill="${escapeHtml(iconColor)}" d="${HOME_PATH}"/></svg>`;
 
       const otherCount = count - zoneCount;
       const badge = otherCount > 0 ? (() => {

--- a/tests/marker-icon.test.ts
+++ b/tests/marker-icon.test.ts
@@ -144,6 +144,40 @@ describe('createMarkerIconForMarker', () => {
     // entity_picture returns an L.Icon with the picture URL, not a coloured SVG
     expect(result.iconUrl).toBe('/api/image/john.jpg');
   });
+
+  // ── XSS: color / icon are user config (e.g. pasted from an untrusted
+  // dashboard share), not just a hex string or "mdi:name" — L.divIcon's
+  // html option is assigned via innerHTML, so an unescaped value here can
+  // break out of the SVG/ha-icon attribute it's interpolated into. ────────
+
+  describe('escapes color and icon before interpolating into divIcon html', () => {
+    it('MDI icon: escapes a color value that tries to break out of the style attribute', () => {
+      const malicious = '"><script>alert(1)</script>';
+      const result = createMarkerIconForMarker({ icon: 'mdi:home', color: malicious }, mockHass(), 'light') as any;
+      expect(result.html).not.toContain('<script>');
+      expect(result.html).toContain('&lt;script&gt;');
+      expect(result.html).toContain('&quot;&gt;');
+    });
+
+    it('MDI icon: escapes an icon value that tries to break out of the icon attribute', () => {
+      const malicious = 'mdi:home"><img src=x onerror=alert(1)>';
+      const result = createMarkerIconForMarker({ icon: malicious }, mockHass(), 'light') as any;
+      expect(result.html).not.toContain('<img');
+      expect(result.html).toContain('&lt;img');
+    });
+
+    it('default icon (inline SVG): escapes a color value that tries to break out of the fill attribute', () => {
+      const malicious = '"/><script>alert(1)</script>';
+      const result = createMarkerIconForMarker({ color: malicious }, mockHass(), 'light') as any;
+      expect(result.html).not.toContain('<script>');
+      expect(result.html).toContain('&lt;script&gt;');
+    });
+
+    it('a well-behaved hex color still renders normally (no over-escaping)', () => {
+      const result = createMarkerIconForMarker({ icon: 'mdi:home', color: '#ff0000' }, mockHass(), 'light') as any;
+      expect(result.html).toContain('color: #ff0000');
+    });
+  });
 });
 
 // ── findPersonEntityForDeviceTracker ─────────────────────────────────────────


### PR DESCRIPTION
Closes the one gap found in an XSS audit of external-data rendering (NWS alerts, wildfires, lightning popups were already consistently escaped via `escapeHtml()` — see conversation for the full audit).

## The gap

`markers:` config's `color` and `icon` fields were interpolated **unescaped** into the marker's inline SVG / `<ha-icon>` HTML in `marker-icon.ts` and the cluster-representative-icon code in `weather-radar-card.ts`. `L.divIcon`'s `html` option is assigned via `innerHTML`, so a crafted value could break out of the attribute it's interpolated into.

Not externally reachable — it's the dashboard owner's own YAML, not wire/API data — but a value pasted from an untrusted dashboard share (a forum post, etc.) without review could inject HTML/script. Same threat class as everything else already protected, so closed the same way: `escapeHtml()`, the helper already used for every other user-visible HTML interpolation point in the codebase.

## Changes
- `marker-icon.ts` — escape `colour` and `iconType` at both interpolation sites.
- `weather-radar-card.ts` — same for the cluster representative-icon builder (`repIcon`/`iconColor`).
- `tests/marker-icon.test.ts` — 4 new tests confirming a crafted `color`/`icon` value can't break out of the attribute, plus one confirming normal values still render unescaped-looking (no over-escaping).

685 tests passing, build clean. Held locally (not pushed) until now per the "security fixes don't go out ahead of a release" policy — folding into the in-progress 3.7.3-beta3 cut.