### PR TITLE
fix: honour hass.locale.time_format for timestamps instead of guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Timestamps now follow Home Assistant's own Time format setting instead of guessing from the browser.** The radar timeline and NWS alert Effective/Expires times used `Intl.DateTimeFormat`/`Date#toLocaleString` with the browser's ambient locale to decide 12h vs 24h — an unreliable signal, since many users run an en-US browser/OS language regardless of where they live, and even an explicit OS 24-hour override often isn't honoured by `Intl`'s locale resolution. Both now defer to `hass.locale.time_format` (Settings → General) via `custom-card-helpers`' `formatTime`/`formatDateTime` — the same helpers HA's own frontend uses — falling back to the previous browser-locale behavior when unavailable. ([#239](https://github.com/jpettitt/weather-radar-card/issues/239))
+
 ## [3.7.3] - 2026-08-20
 
 > **Stable release.** Graduates the 3.7.3 line (`start_paused`, `preload_while_hidden`, DWD server-error handling, marker config-escaping hardening) to stable. Drop-in upgrade from 3.7.2 — no config changes required. The entries below are what changed since `3.7.2`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ The user-facing knobs are summarised here. For the rendering architecture (two-s
 
 **Timeline scrubbing** — click anywhere on the progress bar to jump to that frame, or click and drag to scrub through the loop. Dragging pauses the animation; releasing resumes it if playback was active. On touchscreen dashboards, set `progress_bar_touch_height: 44` to create a larger scrub target. The extra touch area overlays the lower edge of the map; it does not increase the visible 8 px track or bottom chrome height.
 
-**Timestamp** — uses the browser's locale via `Intl.DateTimeFormat`, so 12 h (AM/PM) or 24 h format is chosen automatically based on the user's regional settings. On narrow cards (≤ 397 px) the date prefix is hidden; only the time remains visible.
+**Timestamp** — the time (hour:minute) follows Home Assistant's own **Time format** setting (your profile → General), the same as the rest of the HA frontend; falls back to the browser's locale if `hass`/locale isn't available for some reason. The date part (weekday/day/month) always follows the browser's locale. On narrow cards (≤ 397 px) the date prefix is hidden; only the time remains visible.
 
 **Crossfade** (`animated_transitions: true`) — a two-slot crossfade. The new frame fades in over a "cushion" of the previous frame held at full opacity; the cushion then fades out via CSS `transition-delay`. Avoids the alpha-compositing dip that a naive symmetric crossfade produces against light basemaps.
 

--- a/src/nws-alerts-layer.ts
+++ b/src/nws-alerts-layer.ts
@@ -1,5 +1,5 @@
 import * as L from 'leaflet';
-import { HomeAssistant } from 'custom-card-helpers';
+import { HomeAssistant, formatDateTime as haFormatDateTime, type FrontendLocaleData } from 'custom-card-helpers';
 import { WeatherRadarCardConfig } from './types';
 import { localize } from './localize/localize';
 import { colorForEvent, NWS_ALERT_DEFAULT_COLOR } from './nws-alert-colors';
@@ -494,7 +494,7 @@ export class NwsAlertsLayer {
         // height so a long alert description never spills outside the card;
         // Leaflet adds an internal scrollbar past the cap.
         layer.bindPopup(
-          buildPopupHtml(feature.properties as AlertProps | null),
+          buildPopupHtml(feature.properties as AlertProps | null, this._hass?.locale),
           { autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight() },
         );
       },
@@ -615,13 +615,13 @@ function paintOrderAscending(a: GeoJSON.Feature, b: GeoJSON.Feature): number {
   return ca - cb;
 }
 
-function buildPopupHtml(props: AlertProps | null): string {
+function buildPopupHtml(props: AlertProps | null, locale: FrontendLocaleData | undefined): string {
   const event = props?.event ?? localize('ui.alerts.unknown_event');
   const severity = props?.severity ?? '—';
   const certainty = props?.certainty ?? '—';
   const urgency = props?.urgency ?? '—';
-  const effective = formatDateTime(props?.effective);
-  const expires = formatDateTime(props?.expires ?? props?.ends);
+  const effective = formatDateTime(props?.effective, locale);
+  const expires = formatDateTime(props?.expires ?? props?.ends, locale);
   const headline = props?.headline ?? '';
   // NWS descriptions are free-text bodies of the alert (winds, hail size,
   // location, recommended actions). They preserve their own line breaks —
@@ -673,11 +673,17 @@ function relativeLuminance(hex: string): number {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-function formatDateTime(s: string | undefined): string {
+// Defers to HA's own time_format setting (Settings > General) via
+// custom-card-helpers' formatDateTime when locale is available — the
+// browser's ambient locale is an unreliable signal for 12h/24h
+// specifically (see the equivalent note in radar-player.ts's
+// _getTimeString). Falls back to the previous browser-locale behaviour
+// otherwise.
+function formatDateTime(s: string | undefined, locale: FrontendLocaleData | undefined): string {
   if (!s) return '—';
   const d = new Date(s);
   if (Number.isNaN(d.getTime())) return s;
-  return d.toLocaleString();
+  return locale ? haFormatDateTime(d, locale) : d.toLocaleString();
 }
 
 // Re-export for the editor to enumerate available categories without

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as L from 'leaflet';
+import { HomeAssistant, formatTime } from 'custom-card-helpers';
 import { WeatherRadarCardConfig } from './types';
 import { Z_RADAR_BASE } from './const';
 import { RateLimiter } from './rate-limiter';
@@ -284,6 +285,16 @@ export interface RadarPlayerOptions {
   rainviewerLimiter: RateLimiter;
   noaaLimiter: RateLimiter;
   dwdLimiter: RateLimiter;
+  /**
+   * Live accessor for hass — used to honour the user's HA-configured
+   * time_format (Settings > General) for the timeline timestamp instead
+   * of guessing from the browser's ambient locale, which is frequently
+   * wrong (many users run an en-US browser/OS language regardless of
+   * where they live, and even an explicit OS 12h/24h override often
+   * isn't honoured by Intl's locale resolution). Optional — falls back
+   * to the previous browser-locale behaviour when absent.
+   */
+  getHass?: () => HomeAssistant | undefined;
 }
 
 // ── RadarPlayer ──────────────────────────────────────────────────────────────
@@ -298,6 +309,7 @@ export class RadarPlayer {
   private _map: L.Map;
   private _shadowRoot: ShadowRoot;
   private _getConfig: () => WeatherRadarCardConfig;
+  private _getHass?: () => HomeAssistant | undefined;
   private _rainviewerLimiter: RateLimiter;
   private _noaaLimiter: RateLimiter;
   private _dwdLimiter: RateLimiter;
@@ -512,6 +524,7 @@ export class RadarPlayer {
     this._map = opts.map;
     this._shadowRoot = opts.shadowRoot;
     this._getConfig = opts.getConfig;
+    this._getHass = opts.getHass;
     this._rainviewerLimiter = opts.rainviewerLimiter;
     this._noaaLimiter = opts.noaaLimiter;
     this._dwdLimiter = opts.dwdLimiter;
@@ -1039,6 +1052,7 @@ export class RadarPlayer {
   // ── Config helpers ───────────────────────────────────────────────────────
 
   private get _cfg(): WeatherRadarCardConfig { return this._getConfig(); }
+  private get _hass(): HomeAssistant | undefined { return this._getHass?.(); }
   // Effective per-frame delay = configured frame_delay divided by the user's
   // playback-speed multiplier. Multiplier > 1 plays faster, < 1 plays slower.
   // Defaults to 1× (unchanged) when the user hasn't touched the speed button.
@@ -2204,16 +2218,25 @@ export class RadarPlayer {
   // Format date and time as separate parts. The bottom-row template
   // wraps each in its own span so a container query can hide the date
   // when the card is narrow (~< 398 px) and only the time stays
-  // visible. Uses the user's browser locale via Intl.DateTimeFormat.
+  // visible. Date stays on the browser's ambient locale (day/month
+  // naming — not what was reported wrong). Time defers to HA's own
+  // time_format setting (Settings > General) via custom-card-helpers'
+  // formatTime, the same helper HA's own frontend uses — the browser's
+  // ambient locale is an unreliable signal for 12h/24h specifically:
+  // many users run an en-US browser/OS language regardless of where
+  // they live, and even an explicit OS 24-hour override often isn't
+  // honoured by Intl's locale resolution. Falls back to the previous
+  // browser-locale behaviour when hass/locale isn't available.
   private _getTimeString(epochMs: number): { date: string; time: string } {
     const d = new Date(epochMs);
+    const locale = this._hass?.locale;
     return {
       date: new Intl.DateTimeFormat(undefined, {
         weekday: 'short', day: 'numeric', month: 'short',
       }).format(d),
-      time: new Intl.DateTimeFormat(undefined, {
-        hour: 'numeric', minute: '2-digit',
-      }).format(d),
+      time: locale
+        ? formatTime(d, locale)
+        : new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(d),
     };
   }
 

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -741,6 +741,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       map: this._map,
       shadowRoot: this.shadowRoot!,
       getConfig: () => this._config,
+      getHass: () => this.hass,
       rainviewerLimiter,
       noaaLimiter,
       dwdLimiter,

--- a/tests/nws-alerts-helpers.test.ts
+++ b/tests/nws-alerts-helpers.test.ts
@@ -289,15 +289,15 @@ describe('relativeLuminance', () => {
 
 describe('formatDateTime', () => {
   it('returns "—" for undefined', () => {
-    expect(formatDateTime(undefined)).toBe('—');
+    expect(formatDateTime(undefined, undefined)).toBe('—');
   });
 
   it('returns "—" for empty string', () => {
-    expect(formatDateTime('')).toBe('—');
+    expect(formatDateTime('', undefined)).toBe('—');
   });
 
-  it('formats a valid ISO timestamp via Date.toLocaleString', () => {
-    const result = formatDateTime('2026-05-02T17:25:00-07:00');
+  it('without a locale, formats via Date.toLocaleString (browser-locale fallback)', () => {
+    const result = formatDateTime('2026-05-02T17:25:00-07:00', undefined);
     // toLocaleString output varies by environment locale, but it should
     // be non-trivial and contain a year.
     expect(result.length).toBeGreaterThan(5);
@@ -305,7 +305,26 @@ describe('formatDateTime', () => {
   });
 
   it('returns the input unchanged when it isn\'t parseable', () => {
-    expect(formatDateTime('not a date')).toBe('not a date');
+    expect(formatDateTime('not a date', undefined)).toBe('not a date');
+  });
+
+  // ── hass.locale.time_format (issue #239) ──────────────────────────────
+  //
+  // The browser's ambient locale is an unreliable signal for 12h/24h —
+  // many users run an en-US browser/OS language regardless of where they
+  // live. When a locale is available, defer to HA's own time_format
+  // setting instead (via custom-card-helpers' formatDateTime).
+
+  it('with time_format: "24", never renders AM/PM regardless of language', () => {
+    const locale = { language: 'en', number_format: 'language', time_format: '24' } as any;
+    const result = formatDateTime('2026-05-02T17:25:00-07:00', locale);
+    expect(result).not.toMatch(/AM|PM/i);
+  });
+
+  it('with time_format: "12", renders AM/PM', () => {
+    const locale = { language: 'en', number_format: 'language', time_format: '12' } as any;
+    const result = formatDateTime('2026-05-02T05:25:00-07:00', locale);
+    expect(result).toMatch(/AM|PM/i);
   });
 });
 
@@ -326,7 +345,7 @@ describe('buildPopupHtml — link URL escaping', () => {
 
   it('escapes attribute-breakout characters in the linkUrl', () => {
     const malicious = 'https://api.weather.gov/alerts/foo"><script>alert(1)</script>';
-    const html = buildPopupHtml(minimal(malicious));
+    const html = buildPopupHtml(minimal(malicious), undefined);
     // Raw " must NOT appear in the href value — that would close the attribute.
     expect(html).not.toContain('"><script>');
     // Escaped form must appear instead.
@@ -337,25 +356,25 @@ describe('buildPopupHtml — link URL escaping', () => {
 
   it('a normal NWS uri appears unescaped (only HTML-significant chars are touched)', () => {
     const normal = 'https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.1234';
-    const html = buildPopupHtml(minimal(normal));
+    const html = buildPopupHtml(minimal(normal), undefined);
     expect(html).toContain(`href="${normal}"`);
   });
 
   it('javascript: URIs trigger the fallback to the alerts index (scheme check)', () => {
-    const html = buildPopupHtml(minimal('javascript:alert(1)'));
+    const html = buildPopupHtml(minimal('javascript:alert(1)'), undefined);
     expect(html).toContain('href="https://www.weather.gov/alerts"');
     expect(html).not.toContain('javascript:');
   });
 
   it('null / undefined uri falls back to the alerts index', () => {
-    expect(buildPopupHtml(minimal(null))).toContain('href="https://www.weather.gov/alerts"');
-    expect(buildPopupHtml(minimal(undefined))).toContain('href="https://www.weather.gov/alerts"');
+    expect(buildPopupHtml(minimal(null), undefined)).toContain('href="https://www.weather.gov/alerts"');
+    expect(buildPopupHtml(minimal(undefined), undefined)).toContain('href="https://www.weather.gov/alerts"');
   });
 
   it('escapes < > & in the uri without converting them back', () => {
     // Hypothetical NWS uri with HTML-unsafe characters — verifies the
     // escapeHtml call covers all the standard set, not just the quote.
-    const html = buildPopupHtml(minimal('https://api.weather.gov/alerts/?a=<b>&c=d'));
+    const html = buildPopupHtml(minimal('https://api.weather.gov/alerts/?a=<b>&c=d'), undefined);
     expect(html).toContain('a=&lt;b&gt;&amp;c=d');
     expect(html).not.toContain('?a=<b>');
   });

--- a/tests/radar-player-time-format.test.ts
+++ b/tests/radar-player-time-format.test.ts
@@ -1,0 +1,100 @@
+// Tests for _getTimeString's hass.locale.time_format support (issue #239).
+//
+// The browser's ambient locale is an unreliable signal for 12h/24h:
+// many users run an en-US browser/OS language regardless of where they
+// live, and even an explicit OS 24-hour override often isn't honoured by
+// Intl's locale resolution. When hass/locale is available, the timeline
+// timestamp defers to HA's own time_format setting (Settings > General)
+// via custom-card-helpers' formatTime instead.
+//
+// Follows the "stub Leaflet, test the helpers" convention.
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('leaflet', () => {
+  class Layer {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as unknown as { WMS: typeof WMS }).WMS = WMS;
+  class Control {
+    constructor(_opts?: unknown) { void _opts; }
+  }
+  const DomUtil = { create: vi.fn(() => ({ style: {}, classList: { add: vi.fn() } })) };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn() };
+  return {
+    Layer, TileLayer, Control, DomUtil, DomEvent,
+    default: { Layer, TileLayer, Control, DomUtil, DomEvent },
+  };
+});
+
+import { RadarPlayer } from '../src/radar-player';
+import type { WeatherRadarCardConfig } from '../src/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function makePlayer(hass: any): RadarPlayer {
+  const map = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getZoom: () => 7,
+    getSize: () => ({ x: 600, y: 400 }),
+    getPane: vi.fn(),
+    createPane: vi.fn(() => ({ style: {} })),
+    getContainer: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0 }) }),
+  } as any;
+  const shadowRoot = { getElementById: () => null, host: {} } as any;
+  return new RadarPlayer({
+    map,
+    shadowRoot,
+    getConfig: () => ({ type: 'custom:weather-radar-card' } as WeatherRadarCardConfig),
+    getHass: () => hass,
+    rainviewerLimiter: {} as any,
+    noaaLimiter: {} as any,
+    dwdLimiter: {} as any,
+  });
+}
+
+// 15:00 local time in a fixed, unambiguous instant.
+const AFTERNOON_MS = new Date('2026-08-20T15:00:00').getTime();
+
+describe('_getTimeString time_format handling', () => {
+  it('without hass, falls back to the previous browser-locale behaviour (no throw, produces a time)', () => {
+    const p = makePlayer(undefined) as any;
+    const result = p._getTimeString(AFTERNOON_MS);
+    expect(typeof result.time).toBe('string');
+    expect(result.time.length).toBeGreaterThan(0);
+  });
+
+  it('hass.locale.time_format: "24" never renders AM/PM', () => {
+    const hass = { locale: { language: 'en', number_format: 'language', time_format: '24' } };
+    const p = makePlayer(hass) as any;
+    const result = p._getTimeString(AFTERNOON_MS);
+    expect(result.time).not.toMatch(/AM|PM/i);
+  });
+
+  it('hass.locale.time_format: "12" renders AM/PM', () => {
+    const hass = { locale: { language: 'en', number_format: 'language', time_format: '12' } };
+    const p = makePlayer(hass) as any;
+    const result = p._getTimeString(AFTERNOON_MS);
+    expect(result.time).toMatch(/AM|PM/i);
+  });
+
+  it('hass.locale.time_format: "system" derives from the runtime default locale, not language', () => {
+    // en locale would normally imply 12h, but "system" ignores language
+    // and asks Date#toLocaleString(undefined) whether AM/PM appears —
+    // this just needs to run without throwing and produce a time string,
+    // since the actual answer depends on the test runner's own locale.
+    const hass = { locale: { language: 'en', number_format: 'language', time_format: 'system' } };
+    const p = makePlayer(hass) as any;
+    const result = p._getTimeString(AFTERNOON_MS);
+    expect(typeof result.time).toBe('string');
+    expect(result.time.length).toBeGreaterThan(0);
+  });
+
+  it('the date part is unaffected by time_format (still weekday/day/month)', () => {
+    const hass = { locale: { language: 'en', number_format: 'language', time_format: '24' } };
+    const p = makePlayer(hass) as any;
+    const result = p._getTimeString(AFTERNOON_MS);
+    expect(result.date).toMatch(/2026|Aug/i);
+  });
+});


### PR DESCRIPTION
Closes #239.

## The complaint

A European user reported the timeline showing 12h AM/PM despite being in Europe, and pushed back that a correctly-configured OS + Chrome "should" default to 24h automatically. That's true in the ideal case, but `Intl.DateTimeFormat(undefined,...)`/`Date#toLocaleString()` are unreliable signals for 12h/24h specifically:

1. **Language and region are configured separately, and most people never touch the language part.** Many European users run their OS/browser *language* at `en-US` (common on US-purchased hardware, or just because English software ships as default) even though region/timezone is correct. `Intl` resolves off the language tag, not physical region, so it silently falls back to `en-US`'s default (12h).
2. **Even where the OS exposes an explicit 12h/24h override independent of language** (e.g. macOS's Language & Region pane), browsers don't reliably honour it — that override isn't part of the resolved BCP-47 locale tag `Intl` uses, so it falls back to the locale's default convention. Long-documented cross-browser inconsistency, not specific to this card.

## The fix

Home Assistant already has an explicit, user-controlled signal for this — `hass.locale.time_format` (Settings → General → Time format) — which sidesteps the whole unreliable ambient-locale-resolution chain. `custom-card-helpers` (already a dependency) exports `formatTime`/`formatDateTime`, the *same* helpers HA's own frontend uses to make this exact decision, so I reused those rather than reimplementing the logic.

- **`radar-player.ts`** — `RadarPlayer` had no `hass` access at all (constructor only took map/config/rate-limiters). Added an optional `getHass` accessor, matching the existing `getConfig` live-getter pattern. `_getTimeString`'s time part now prefers `formatTime(d, hass.locale)`; the date part (weekday/day/month) stays on the browser locale — unrelated to the report, untouched.
- **`nws-alerts-layer.ts`** — `NwsAlertsLayer` already had `hass`; threaded `locale` through `buildPopupHtml` into the alert popup's Effective/Expires `formatDateTime` call, closing the same gap there.
- **Left alone, and said why in the commit:** lightning's popup shows relative age + distance, no clock time; wildfire's discovery date has no time-of-day component. Neither is affected by 12h/24h.

## Docs

`docs/configuration.md`'s Timestamp note updated to describe the new precedence (HA setting → browser-locale fallback).

## Tests

7 new tests: 5 in a new `tests/radar-player-time-format.test.ts` (`'24'` never shows AM/PM, `'12'` always does, `'system'` doesn't throw and produces a time, the date part is unaffected, no-hass fallback still works), 2 added to `tests/nws-alerts-helpers.test.ts` for the alert-popup path. Updated existing `buildPopupHtml`/`formatDateTime` call sites for the new `locale` parameter. 692 tests passing, build clean.