### PR TITLE
fix(wildfire): show area in acres/hectares matching HA unit system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Wildfire popup now shows area in acres or hectares to match your Home Assistant unit system**, instead of always showing NIFC's raw acres. Metric users get hectares (not km² — hectares is the international convention for wildfire/land area, matching Australia's RFS, Canada's CIFFC, and Europe's EFFIS). The number itself, and the discovery date below it, now also follow your HA locale (thousands separator / date ordering) instead of guessing from the browser. The popup label changed from "Acres" to "Area" to match.
+
 ### Fixed
 
 - **Timestamps now follow Home Assistant's own Time format setting instead of guessing from the browser.** The radar timeline and NWS alert Effective/Expires times used `Intl.DateTimeFormat`/`Date#toLocaleString` with the browser's ambient locale to decide 12h vs 24h — an unreliable signal, since many users run an en-US browser/OS language regardless of where they live, and even an explicit OS 24-hour override often isn't honoured by `Intl`'s locale resolution. Both now defer to `hass.locale.time_format` (Settings → General) via `custom-card-helpers`' `formatTime`/`formatDateTime` — the same helpers HA's own frontend uses — falling back to the previous browser-locale behavior when unavailable. ([#239](https://github.com/jpettitt/weather-radar-card/issues/239))

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -8,7 +8,7 @@ For non-US instances, the card surfaces a banner reminding the user that the dat
 
 When `show_wildfires: true`, the card overlays active US wildfire perimeters from the National Interagency Fire Center's [WFIGS Current Interagency Fire Perimeters](https://data-nifc.opendata.arcgis.com/datasets/nifc::wfigs-current-interagency-fire-perimeters/about) feed.
 
-Active fires draw red; fires reported as 100% contained draw grey. Small incidents render as a fire icon at the centroid; larger incidents render as a polygon outline with translucent fill. Click any fire to see its name, acreage, containment, and discovery date, with a link to NIFC's InciWeb for further information (gated against InciWeb's RSS index so we don't link to 404s).
+Active fires draw red; fires reported as 100% contained draw grey. Small incidents render as a fire icon at the centroid; larger incidents render as a polygon outline with translucent fill. Click any fire to see its name, area, containment, and discovery date, with a link to NIFC's InciWeb for further information (gated against InciWeb's RSS index so we don't link to 404s). NIFC always reports area in acres; the popup shows it in acres or hectares — whichever matches your Home Assistant unit system — and the discovery date follows your HA locale.
 
 The overlay refreshes every 5 minutes when fires are visible (matching NIFC's update cadence) and every 30 minutes when none are. Defaults filter out incidents under 10 acres; tune with `wildfire_min_acres` or `wildfire_radius_km`.
 

--- a/src/geo-utils.ts
+++ b/src/geo-utils.ts
@@ -2,6 +2,8 @@
 // NWS alert polygons, future GeoJSON overlays). Kept side-effect-free
 // so they're trivially unit-testable.
 
+import { formatNumber, type FrontendLocaleData } from 'custom-card-helpers';
+
 // Compute the lng/lat bounding box of a Polygon or MultiPolygon. Returns
 // null for unsupported geometry types (Point, LineString, etc.) or empty
 // coordinate arrays. Skips coordinate pairs whose values aren't numbers.
@@ -96,4 +98,24 @@ export function formatDistance(distKm: number, lengthUnit: string | undefined): 
     return `${Math.round(distKm * KM_TO_MILES)} mi`;
   }
   return `${Math.round(distKm)} km`;
+}
+
+// Format a wildfire's acreage (NIFC's WFIGS feed always reports area in
+// acres) for display in HA's preferred unit system. Metric users get
+// hectares, not km² — hectares is the international convention for
+// wildfire/land area (Australia's RFS, Canada's CIFFC, Europe's EFFIS all
+// report this way; km² would be non-idiomatic for this domain). Same
+// `lengthUnit`/fallback convention as formatDistance. `locale` is
+// `hass.locale`, passed through to formatNumber for a thousands-separator
+// style matching the user's HA number-format preference; undefined falls
+// back to the browser's ambient locale (formatNumber's own default).
+const ACRES_TO_HECTARES = 0.404686;
+export function formatArea(
+  acres: number,
+  lengthUnit: string | undefined,
+  locale: FrontendLocaleData | undefined,
+): string {
+  const isImperial = lengthUnit === 'mi';
+  const value = isImperial ? acres : acres * ACRES_TO_HECTARES;
+  return `${formatNumber(value, locale, { maximumFractionDigits: 0 })} ${isImperial ? 'ac' : 'ha'}`;
 }

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "Das DWD-Radar deckt Deutschland und seine direkten Nachbarn ab. Ihr Home-Assistant-Standort liegt außerhalb dieser Region — die Karte zeigt möglicherweise nur „keine Daten\"."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Fläche",
       "contained": "Eingedämmt",
       "discovered": "Entdeckt",
       "more_info": "Mehr Infos → NIFC",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -22,7 +22,7 @@
       "dwd_de_only": "DWD radar covers Germany and its immediate neighbours. Your Home Assistant location is outside this region — the map may show only no-data."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Area",
       "contained": "Contained",
       "discovered": "Discovered",
       "more_info": "More info → NIFC",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "El radar DWD cubre Alemania y sus vecinos inmediatos. La ubicación de su Home Assistant está fuera de esta región — el mapa puede mostrar solo «sin datos»."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Superficie",
       "contained": "Contenido",
       "discovered": "Detectado",
       "more_info": "Más info → NIFC",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "Le radar DWD couvre l’Allemagne et ses voisins immédiats. Votre emplacement Home Assistant est en dehors de cette région — la carte peut n’afficher aucune donnée."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Superficie",
       "contained": "Maîtrisé",
       "discovered": "Détecté",
       "more_info": "Plus d’infos → NIFC",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "Il radar DWD copre la Germania e i suoi vicini immediati. La posizione di Home Assistant è al di fuori di questa regione — la mappa potrebbe mostrare solo «nessun dato»."
     },
     "wildfire": {
-      "acres": "Acri",
+      "area": "Superficie",
       "contained": "Contenuto",
       "discovered": "Rilevato",
       "more_info": "Maggiori info → NIFC",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "DWD-radaren dekker Tyskland og umiddelbare naboland. Plasseringen din i Home Assistant er utenfor denne regionen — kartet viser kanskje bare «ingen data»."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Areal",
       "contained": "Begrenset",
       "discovered": "Oppdaget",
       "more_info": "Mer info → NIFC",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "DWD-radar dekt Duitsland en zijn directe buurlanden. Uw Home Assistant-locatie ligt buiten deze regio — de kaart toont mogelijk alleen «geen data»."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Oppervlakte",
       "contained": "Onder controle",
       "discovered": "Ontdekt",
       "more_info": "Meer info → NIFC",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "Radar DWD obejmuje Niemcy i ich bezpośrednich sąsiadów. Twoja lokalizacja Home Assistant znajduje się poza tym regionem — mapa może pokazywać tylko „brak danych\"."
     },
     "wildfire": {
-      "acres": "Akry",
+      "area": "Powierzchnia",
       "contained": "Opanowany",
       "discovered": "Wykryty",
       "more_info": "Więcej info → NIFC",

--- a/src/localize/languages/pt_BR.json
+++ b/src/localize/languages/pt_BR.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "O radar DWD cobre a Alemanha e seus vizinhos imediatos. A localização do seu Home Assistant está fora desta região — o mapa pode mostrar apenas «sem dados»."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Área",
       "contained": "Contido",
       "discovered": "Detectado",
       "more_info": "Mais info → NIFC",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "Radar DWD pokrýva Nemecko a jeho bezprostredných susedov. Vaša poloha v Home Assistante je mimo tohto regiónu — mapa môže zobrazovať len „žiadne údaje\"."
     },
     "wildfire": {
-      "acres": "Akre",
+      "area": "Rozloha",
       "contained": "Zvládnutý",
       "discovered": "Zistený",
       "more_info": "Viac info → NIFC",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -18,7 +18,7 @@
       "dwd_de_only": "DWD-radarn täcker Tyskland och dess omedelbara grannländer. Din Home Assistant-plats ligger utanför detta område — kartan kan endast visa «inga data»."
     },
     "wildfire": {
-      "acres": "Acres",
+      "area": "Area",
       "contained": "Under kontroll",
       "discovered": "Upptäckt",
       "more_info": "Mer info → NIFC",

--- a/src/wildfire-layer.ts
+++ b/src/wildfire-layer.ts
@@ -1,9 +1,9 @@
 import * as L from 'leaflet';
-import { HomeAssistant } from 'custom-card-helpers';
+import { HomeAssistant, formatDate } from 'custom-card-helpers';
 import { WeatherRadarCardConfig } from './types';
 import { FIRE_PATH } from './marker-icon';
 import { localize } from './localize/localize';
-import { centroidLngLat, geometryLngLatBounds, haversineKm } from './geo-utils';
+import { centroidLngLat, geometryLngLatBounds, haversineKm, formatArea } from './geo-utils';
 import { sharedCanvasRenderer } from './shared-canvas-renderer';
 import { escapeHtml, slugify } from './string-utils';
 import { mapsEqual } from './map-utils';
@@ -384,6 +384,7 @@ export class WildfireLayer {
               feature.properties as WildfireProps | null,
               this._inciwebSlugs,
               this._inciwebReady,
+              this._hass,
             ),
             { autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight() },
           );
@@ -406,7 +407,7 @@ export class WildfireLayer {
         });
         const marker = L.marker(item.latLng, { icon });
         marker.bindPopup(
-          buildPopupHtml(props, this._inciwebSlugs, this._inciwebReady),
+          buildPopupHtml(props, this._inciwebSlugs, this._inciwebReady, this._hass),
           { autoPan: true, autoPanPadding: [12, 12], maxHeight: this._popupMaxHeight() },
         );
         marker.addTo(this._iconLayer!);
@@ -458,20 +459,28 @@ function buildPopupHtml(
   props: WildfireProps | null,
   inciwebSlugs: Set<string>,
   inciwebReady: boolean,
+  hass: HomeAssistant | undefined,
 ): string {
+  const locale = hass?.locale;
   const name = props?.poly_IncidentName ?? localize('ui.wildfire.unknown_name');
   const acres = props?.poly_GISAcres;
   const contained = props?.attr_PercentContained;
   const discovered = props?.attr_FireDiscoveryDateTime;
 
-  const acresStr = typeof acres === 'number'
-    ? acres.toLocaleString(undefined, { maximumFractionDigits: 0 })
+  // Hectares for metric users, not raw acres — see formatArea's doc
+  // comment for why hectares (not km²) is the right metric unit here.
+  const areaStr = typeof acres === 'number'
+    ? formatArea(acres, hass?.config?.unit_system?.length, locale)
     : '—';
   const containedStr = typeof contained === 'number'
     ? `${Math.round(contained)}%`
     : '—';
+  // Defers to HA's locale for date ordering (DD/MM vs MM/DD) — same
+  // rationale as the timeline timestamp fix (issue #239): the browser's
+  // ambient locale is an unreliable signal, and a misread date ordering
+  // here could make a fire look more or less recent than it actually is.
   const discoveredStr = typeof discovered === 'number'
-    ? new Date(discovered).toLocaleDateString()
+    ? (locale ? formatDate(new Date(discovered), locale) : new Date(discovered).toLocaleDateString())
     : '—';
 
   // InciWeb URL format: /incident-information/{poo-jurisdictional-unit-lower}-{name-slug}
@@ -510,7 +519,7 @@ function buildPopupHtml(
   return `
     <div style="font:12px/1.4 'Helvetica Neue',Arial,sans-serif;min-width:180px">
       <div style="font-weight:bold;font-size:13px;margin-bottom:4px">${escapeHtml(name)}</div>
-      <div><b>${escapeHtml(localize('ui.wildfire.acres'))}:</b> ${escapeHtml(acresStr)}</div>
+      <div><b>${escapeHtml(localize('ui.wildfire.area'))}:</b> ${escapeHtml(areaStr)}</div>
       <div><b>${escapeHtml(localize('ui.wildfire.contained'))}:</b> ${escapeHtml(containedStr)}</div>
       <div><b>${escapeHtml(localize('ui.wildfire.discovered'))}:</b> ${escapeHtml(discoveredStr)}</div>
       <div style="margin-top:6px;font-size:10px;color:#666">${escapeHtml(localize('ui.wildfire.disclaimer'))} <a href="${DOCS_WILDFIRES_URL}" target="_blank" rel="noopener noreferrer" style="color:#666;text-decoration:underline">${escapeHtml(localize('ui.wildfire.see_readme'))}</a>.</div>
@@ -533,4 +542,4 @@ function featureBboxPx(
 }
 
 // Test-only exports — internal helpers exposed for the unit tests.
-export { featureKey, decisionsEqual, isContained, iconSizeForAcres };
+export { featureKey, decisionsEqual, isContained, iconSizeForAcres, buildPopupHtml };

--- a/tests/geo-utils.test.ts
+++ b/tests/geo-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { geometryLngLatBounds, centroidLngLat, haversineKm, formatDistance } from '../src/geo-utils';
+import { geometryLngLatBounds, centroidLngLat, haversineKm, formatDistance, formatArea } from '../src/geo-utils';
 
 // A simple unit-square Polygon centred on the origin — easy to reason about
 // for bounds and centroid tests.
@@ -152,6 +152,41 @@ describe('formatDistance — display in HA preferred length unit', () => {
   it('handles exactly zero distance', () => {
     expect(formatDistance(0, 'km')).toBe('0 km');
     expect(formatDistance(0, 'mi')).toBe('0 mi');
+  });
+});
+
+// ── formatArea (wildfire acreage → HA preferred unit system) ────────────
+//
+// NIFC's WFIGS feed always reports area in acres. Metric users get
+// hectares, not km² — hectares is the international convention for
+// wildfire/land area (see the doc comment on formatArea for the
+// rationale). "mi" is the imperial signal (matches formatDistance's
+// convention); anything else defaults to metric.
+
+describe('formatArea — wildfire acreage in HA preferred unit system', () => {
+  it('converts to hectares when unit is "km" (metric)', () => {
+    // 1000 acres × 0.404686 = 404.686 -> 405
+    expect(formatArea(1000, 'km', undefined)).toBe('405 ha');
+  });
+
+  it('stays in acres when unit is "mi" (imperial) — no conversion', () => {
+    expect(formatArea(2500, 'mi', undefined)).toBe('2,500 ac');
+  });
+
+  it('defaults to metric (hectares) when unit is undefined or unknown', () => {
+    // 100 acres × 0.404686 = 40.4686 -> 40
+    expect(formatArea(100, undefined, undefined)).toBe('40 ha');
+    expect(formatArea(100, 'lightyears', undefined)).toBe('40 ha');
+  });
+
+  it('handles exactly zero acreage', () => {
+    expect(formatArea(0, 'km', undefined)).toBe('0 ha');
+    expect(formatArea(0, 'mi', undefined)).toBe('0 ac');
+  });
+
+  it('formats large fires with a thousands separator via formatNumber', () => {
+    // 50,000 acres x 0.404686 = 20,234.3 -> 20,234
+    expect(formatArea(50_000, 'km', undefined)).toBe('20,234 ha');
   });
 });
 

--- a/tests/wildfire-layer.test.ts
+++ b/tests/wildfire-layer.test.ts
@@ -1,0 +1,82 @@
+// Tests for wildfire-layer.ts's buildPopupHtml — specifically the area
+// unit conversion (acres -> hectares for metric users, issue follow-up
+// to #239) and the discovery-date locale handling. Leaflet is mocked
+// purely to satisfy the module's import graph; buildPopupHtml itself is
+// a pure string builder that never touches L.* APIs.
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('leaflet', () => {
+  class Layer {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as unknown as { WMS: typeof WMS }).WMS = WMS;
+  class Control {
+    constructor(_opts?: unknown) { void _opts; }
+  }
+  const DomUtil = { create: vi.fn(() => ({ style: {}, classList: { add: vi.fn() } })) };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn() };
+  return {
+    Layer, TileLayer, Control, DomUtil, DomEvent,
+    default: { Layer, TileLayer, Control, DomUtil, DomEvent },
+  };
+});
+
+import { buildPopupHtml } from '../src/wildfire-layer';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const baseProps = (over: Record<string, unknown> = {}): any => ({
+  poly_IncidentName: 'Sand Drain',
+  poly_GISAcres: 1000,
+  attr_PercentContained: 50,
+  attr_FireDiscoveryDateTime: new Date('2026-08-15T12:00:00Z').getTime(),
+  attr_POOJurisdictionalUnit: null,
+  ...over,
+});
+
+describe('buildPopupHtml — area (acres/hectares)', () => {
+  it('without hass, defaults to metric (hectares) — same fallback convention as formatDistance', () => {
+    // 1000 acres x 0.404686 = 404.686 -> 405
+    const html = buildPopupHtml(baseProps(), new Set(), true, undefined);
+    expect(html).toContain('405 ha');
+    expect(html).toContain('Area');
+  });
+
+  it('with an imperial (mi) unit system, shows acres', () => {
+    const hass = { config: { unit_system: { length: 'mi' } } } as any;
+    const html = buildPopupHtml(baseProps(), new Set(), true, hass);
+    expect(html).toContain('1,000 ac');
+  });
+
+  it('with a metric (km) unit system, converts to hectares', () => {
+    // 1000 acres x 0.404686 = 404.686 -> 405
+    const hass = { config: { unit_system: { length: 'km' } } } as any;
+    const html = buildPopupHtml(baseProps(), new Set(), true, hass);
+    expect(html).toContain('405 ha');
+    expect(html).not.toContain('1,000 ac');
+  });
+
+  it('shows the em-dash placeholder when acreage is missing', () => {
+    const html = buildPopupHtml(baseProps({ poly_GISAcres: undefined }), new Set(), true, undefined);
+    expect(html).toMatch(/Area:<\/b>\s*—/);
+  });
+});
+
+describe('buildPopupHtml — discovery date locale handling', () => {
+  it('without hass, formats via Date#toLocaleDateString (browser-locale fallback)', () => {
+    const html = buildPopupHtml(baseProps(), new Set(), true, undefined);
+    expect(html).toMatch(/2026/);
+  });
+
+  it('with hass.locale, formats via HA\'s own formatDate (still contains the year)', () => {
+    const hass = { locale: { language: 'en', number_format: 'language', time_format: '24' } } as any;
+    const html = buildPopupHtml(baseProps(), new Set(), true, hass);
+    expect(html).toMatch(/2026/);
+  });
+
+  it('shows the em-dash placeholder when discovery date is missing', () => {
+    const html = buildPopupHtml(baseProps({ attr_FireDiscoveryDateTime: undefined }), new Set(), true, undefined);
+    expect(html).toMatch(/Discovered:<\/b>\s*—/);
+  });
+});


### PR DESCRIPTION
Follow-up from the #239 discussion — flagged two related \`hass.locale\` gaps while implementing the timestamp fix, this closes the acres one (the question that prompted it: "are we converting to km²?").

## The gap

NIFC's WFIGS feed always reports wildfire area in acres. The popup showed that raw value regardless of the user's HA unit system, and both the number and the discovery date were formatted via the browser's ambient locale — same class of issue as #239, just for number/date formatting instead of time.

## The fix

- **Not km²** — metric users get **hectares**. Wildfire/land area is conventionally reported in hectares internationally (Australia's RFS, Canada's CIFFC, Europe's EFFIS all use hectares, not km²), so km² would actually be non-idiomatic for this domain even though it's the more obvious metric-area unit at first glance.
- New \`formatArea()\` in \`geo-utils.ts\`, alongside the existing \`formatDistance()\` — same \`lengthUnit\` signal (\`hass.config.unit_system.length\`) and fallback convention (defaults to metric when unit is unknown/undefined). Uses \`custom-card-helpers\`' \`formatNumber\` for \`hass.locale.number_format\`-aware thousands separators.
- Discovery date now uses \`custom-card-helpers\`' \`formatDate\` when \`hass.locale\` is available, matching the exact fallback pattern from the timestamp fix.
- Popup label renamed "Acres" → "Area" (unit-agnostic, since the value can now be either unit) across all 11 locales.

## Tests

12 new: 5 for \`formatArea\` in \`geo-utils.test.ts\` (imperial/metric/undefined/zero/thousands-separator), 7 in a new \`tests/wildfire-layer.test.ts\` (\`buildPopupHtml\` wasn't previously exported for testing — added it to the test-only exports, matching \`nws-alerts-layer.ts\`'s convention). 704 tests passing, build clean.