### PR TITLE
ci: bump actions/upload-artifact to v7 (node24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.node-version == 22
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/


### PR DESCRIPTION
## Summary
- `actions/upload-artifact@v4` targets Node 20, which GitHub Actions runners now force onto Node 24 with a deprecation warning. `v7` declares `node24` natively.

## Test plan
- [x] `npm test` passes locally
- [x] CI build workflow itself exercises this action (coverage upload step)