### PR TITLE
fix(radar-player): load "now" first regardless of past/forecast mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Radar init no longer loads the farthest-future forecast frame before "now" on forecast-heavy configs.** The initial load always fetched frames highest-array-index-first, which coincided with "now" only when there was little/no `forecast_minutes` — for a config like `past_minutes: 0, forecast_minutes: 60`, "now" was index 0 and loaded dead last, so the card showed an hour-ahead forecast frame first and took a full sequential pass through every forecast frame before showing current conditions. The load order now always starts at "now" and fans forward through any forecast frames, then backward through any past frames — unchanged for today's common past-only configs. ([#246](https://github.com/jpettitt/weather-radar-card/issues/246))
+
 ## [3.8.0-beta1] - 2026-08-20
 
 > **Beta pre-release.** Themeable progress-bar colors, HA-locale-aware timestamps and wildfire area/date formatting, plus a CI housekeeping fix. Drop-in upgrade from 3.7.3 — no config changes required.

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -32,6 +32,45 @@ export function nearestFrameIndex(frames: { time: number }[], nowSec: number): n
   return best;
 }
 
+/**
+ * Frame-load order for the initial radar fetch: "now" first, then forward
+ * through any forecast frames, then backward through any past frames.
+ * Pure function — factored out so it's unit-testable without standing up
+ * a full RadarPlayer.
+ *
+ * For a past-only config (no forecast_minutes), nowIndex is already
+ * frameCount-1, so this degenerates to the plain descending
+ * frameCount-1..0 sequence — i.e. today's behavior is unchanged. It's
+ * only a forecast-heavy config (little/no past_minutes) where nowIndex
+ * sits near 0 that this differs: loading highest-index-first there would
+ * load the farthest-future frame before "now" (issue #246).
+ */
+export function buildLoadOrder(frameCount: number, nowIndex: number): number[] {
+  const now = Math.max(0, Math.min(frameCount - 1, nowIndex));
+  const order: number[] = [];
+  for (let fi = now; fi < frameCount; fi++) order.push(fi);
+  for (let fi = now - 1; fi >= 0; fi--) order.push(fi);
+  return order;
+}
+
+/**
+ * Insert `v` into `arr` (assumed already sorted ascending) at its sorted
+ * position, mutating `arr` in place. Returns the insertion index. Pure
+ * function — factored out so it's unit-testable without standing up a
+ * full RadarPlayer.
+ */
+export function insertSorted(arr: number[], v: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < v) lo = mid + 1;
+    else hi = mid;
+  }
+  arr.splice(lo, 0, v);
+  return lo;
+}
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export type FrameStatus = 'empty' | 'loading' | 'loaded' | 'failed';
@@ -1366,13 +1405,25 @@ export class RadarPlayer {
     if (!this.run || this.navPaused || this.viewPaused) return;
     const n = this._loadedSlots.length;
     if (n < 2) return;
+    // delay is fixed at schedule time — if _loadedSlots grows before
+    // this timer fires (the init loop's forward leg appends new frames
+    // at the true tail while the loop is already animating; see
+    // buildLoadOrder), a delay chosen for "this is the last frame"
+    // can end up longer than it needed to be for one tick. Cosmetic
+    // and self-correcting on the very next tick; not worth the timer
+    // cancel/reschedule plumbing a fully-live recompute would need.
     const delay = this._currentSlot === n - 1
       ? this._timeout + this._restartDelay
       : this._timeout;
-    const isLoopBack = this._currentSlot === n - 1;
     setTimeout(() => {
       if (gen !== this._loopGen) return;
-      this._currentSlot = (this._currentSlot + 1) % this._loadedSlots.length;
+      // Re-read _loadedSlots.length fresh rather than closing over `n`
+      // — unlike `delay` above, isLoopBack only affects which transition
+      // style renders on THIS tick, so there's no reason not to use the
+      // current, correct value.
+      const freshN = this._loadedSlots.length;
+      const isLoopBack = this._currentSlot === freshN - 1;
+      this._currentSlot = (this._currentSlot + 1) % freshN;
       // Snap (no fade) when wrapping from the last frame back to the
       // first — the restart-delay pause already breaks the perceived
       // continuity of the animation, so a smooth crossfade across the
@@ -2324,9 +2375,16 @@ export class RadarPlayer {
     // half the captures are still in their decode-wait.
     const snapshotPromises: Promise<void>[] = [];
 
-    let newestShown = false;
+    let firstShown = false;
 
-    for (let fi = frameCount - 1; fi >= 0; fi--) {
+    // "Now" first, then forward through any forecast frames, then
+    // backward through any past frames — see buildLoadOrder's doc-block.
+    // For a past-only config this is exactly the old descending
+    // frameCount-1..0 sequence (nowIndex is already frameCount-1 there).
+    const order = buildLoadOrder(frameCount, this._nowFrameIndex);
+
+    for (let idx = 0; idx < order.length; idx++) {
+      const fi = order[idx];
       if (myGen !== this._frameGeneration || !this._map) return;
 
       this._setSegment(fi, 'loading');
@@ -2345,14 +2403,16 @@ export class RadarPlayer {
 
       if (status === 'loaded') {
         const prevSlotCount = this._loadedSlots.length;
-        this._loadedSlots.unshift(fi);
+        const insertPos = insertSorted(this._loadedSlots, fi);
 
-        // Motion-comp prep: snapshot this frame, then compute the
-        // motion vector(s) we now have enough data for. Frames load
-        // newest first, so after fi snapshots we may be able to
-        // compute motion FROM fi INTO fi+1 (snapshotted last
-        // iteration). motion[fi] itself needs fi-1, which arrives
-        // next iteration.
+        // Motion-comp prep: snapshot this frame, then compute the motion
+        // vector(s) we now have enough data for. _computeMotionForFrame
+        // no-ops (sets null, doesn't compute garbage) when the adjacent
+        // snapshot isn't captured yet, so this is safe regardless of
+        // load order — and _onLayerLoaded's own 'load' listener (wired
+        // in _createLayer before layerSettled's listener) independently
+        // redoes the same computation as each layer settles, so this is
+        // largely a fire-and-forget head start rather than the only path.
         //
         // Fire and forget: _captureFrameSnapshot awaits each tile's
         // decode() so we don't want to block this loop on it. The
@@ -2373,13 +2433,14 @@ export class RadarPlayer {
           );
         }
 
-        if (!newestShown) {
-          // Show newest frame as a static preview before the loop starts.
-          // Layer opacity is 1 — radar_opacity is carried by the radar
-          // pane (see _ensureRadarPane). The shared coverage mask is
-          // already visible (always on), so the preview has its
-          // coverage overlay from the start.
-          newestShown = true;
+        if (!firstShown) {
+          // Show the first-loaded frame ("now", per the load order
+          // above) as a static preview before the loop starts. Layer
+          // opacity is 1 — radar_opacity is carried by the radar pane
+          // (see _ensureRadarPane). The shared coverage mask is already
+          // visible (always on), so the preview has its coverage
+          // overlay from the start.
+          firstShown = true;
           if (el) el.style.opacity = '1';
           this._setTimestamp(fi);
           this._highlightSegment(fi);
@@ -2393,32 +2454,9 @@ export class RadarPlayer {
           this._prev1Slot = this._loadedSlots.indexOf(fi);
         }
 
-        if (this._loadedSlots.length >= 2) {
-          this._radarReady = true;
-          if (prevSlotCount >= 2) {
-            // A new older frame was prepended; shift _currentSlot to keep the
-            // same frame (newest) showing — the running timer continues unaffected.
-            this._currentSlot++;
-            // _prev1Slot is also an index into _loadedSlots, and that array
-            // just grew at the front, so the previously shown slot is now
-            // one step up. Without this shift the next _showSlot tries to
-            // fade out the wrong layer (the freshly loaded one, already at
-            // 0) and the previously visible frame stays orphaned at active
-            // opacity until the loop wraps to slot 0, where snap mode
-            // resets every other layer. That's the ghost trail of stacked
-            // frames visible while later frames are still loading.
-            if (this._prev1Slot >= 0) this._prev1Slot++;
-          } else {
-            // Two frames ready: show the newest and start the loop.
-            // _startLoop sets _currentSlot, calls _showSlot (which sets
-            // _prev1Slot), then _scheduleNext — which returns immediately
-            // when !this.run, so this works for both playing and paused
-            // (start_paused) states without a separate branch.
-            this._startLoop(this._loadedSlots.length - 1);
-          }
-        }
+        this._afterFrameInserted(prevSlotCount, insertPos);
       } else {
-        for (let j = fi - 1; j >= 0; j--) this._setSegment(j, 'failed');
+        this._markRemainingFailed(order, idx + 1);
         break;
       }
     }
@@ -2455,6 +2493,42 @@ export class RadarPlayer {
       this._radarReady = true;
       this._scheduleUpdate();
     }
+  }
+
+  // Record a successfully-loaded frame's effect on playback bootstrap
+  // state, once it's been inserted into _loadedSlots at `insertPos`
+  // (see insertSorted). Frames no longer always load in strict
+  // newest-to-oldest order (see buildLoadOrder), so a new frame can
+  // land at any position, not just the front — inserting at `insertPos`
+  // only shifts existing positions >= insertPos up by one.
+  private _afterFrameInserted(prevSlotCount: number, insertPos: number): void {
+    if (this._loadedSlots.length < 2) return;
+    this._radarReady = true;
+    if (prevSlotCount >= 2) {
+      if (insertPos <= this._currentSlot) this._currentSlot++;
+      if (this._prev1Slot >= 0 && insertPos <= this._prev1Slot) this._prev1Slot++;
+    } else {
+      // First time reaching 2 loaded frames: show "now" and start the
+      // loop. "now" is guaranteed already loaded here — it's always the
+      // first frame attempted (see buildLoadOrder), and a failure on it
+      // aborts the whole init immediately (see _markRemainingFailed's
+      // caller) — so indexOf never misses. _startLoop sets _currentSlot,
+      // calls _showSlot (which sets _prev1Slot), then _scheduleNext —
+      // which returns immediately when !this.run, so this works for
+      // both playing and paused (start_paused) states without a
+      // separate branch.
+      this._startLoop(this._loadedSlots.indexOf(this._nowFrameIndex));
+    }
+  }
+
+  // Mark every not-yet-attempted frame in `order` (from `fromIdx` on) as
+  // failed. Called when a frame fails to load — the init loop aborts
+  // entirely at that point, so everything later in the load order never
+  // gets attempted. `order` isn't a contiguous numeric range once
+  // loading walks outward from "now" (see buildLoadOrder), so this
+  // can't be a simple counting loop over frame indices.
+  private _markRemainingFailed(order: number[], fromIdx: number): void {
+    for (let k = fromIdx; k < order.length; k++) this._setSegment(order[k], 'failed');
   }
 
   // ── Periodic update ──────────────────────────────────────────────────────

--- a/tests/frame-load-order.test.ts
+++ b/tests/frame-load-order.test.ts
@@ -1,0 +1,91 @@
+// Tests for the initial radar-load ordering fix (issue #246): "now" loads
+// first, then forward through any forecast frames, then backward through
+// any past frames — instead of always loading the highest array index
+// first, which for a forecast-heavy config (little/no past_minutes) meant
+// loading the farthest-future frame before "now".
+//
+// Follows the "stub Leaflet, test the helpers" convention.
+
+import { describe, it, expect } from 'vitest';
+
+// Stub Leaflet — radar-player imports it eagerly (and pulls in
+// fetch-tile-layer, which extends L.TileLayer / L.TileLayer.WMS at
+// class-definition time), but buildLoadOrder/insertSorted are pure and
+// never touch any L.* API.
+import { vi } from 'vitest';
+vi.mock('leaflet', () => {
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as any).WMS = WMS;
+  return { TileLayer, default: { TileLayer } };
+});
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { buildLoadOrder, insertSorted } from '../src/radar-player';
+
+describe('buildLoadOrder', () => {
+  it('past-only config (nowIndex = frameCount-1): matches the old descending order', () => {
+    expect(buildLoadOrder(5, 4)).toEqual([4, 3, 2, 1, 0]);
+  });
+
+  it('forecast-only config (nowIndex = 0): ascending order, now first', () => {
+    expect(buildLoadOrder(5, 0)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('mixed config (nowIndex in the middle): forward from now, then backward', () => {
+    expect(buildLoadOrder(6, 2)).toEqual([2, 3, 4, 5, 1, 0]);
+  });
+
+  it('single-frame config', () => {
+    expect(buildLoadOrder(1, 0)).toEqual([0]);
+  });
+
+  it('clamps an out-of-range nowIndex into [0, frameCount-1]', () => {
+    expect(buildLoadOrder(4, 99)).toEqual([3, 2, 1, 0]);
+    expect(buildLoadOrder(4, -5)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('always produces a permutation of 0..frameCount-1', () => {
+    const order = buildLoadOrder(7, 3);
+    expect([...order].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe('insertSorted', () => {
+  it('inserts into an empty array', () => {
+    const arr: number[] = [];
+    expect(insertSorted(arr, 5)).toBe(0);
+    expect(arr).toEqual([5]);
+  });
+
+  it('inserts at the start', () => {
+    const arr = [3, 5, 7];
+    expect(insertSorted(arr, 1)).toBe(0);
+    expect(arr).toEqual([1, 3, 5, 7]);
+  });
+
+  it('inserts in the middle', () => {
+    const arr = [1, 3, 7];
+    expect(insertSorted(arr, 5)).toBe(2);
+    expect(arr).toEqual([1, 3, 5, 7]);
+  });
+
+  it('inserts at the end', () => {
+    const arr = [1, 3, 5];
+    expect(insertSorted(arr, 7)).toBe(3);
+    expect(arr).toEqual([1, 3, 5, 7]);
+  });
+
+  it('duplicate values insert before existing equal entries (stable low-index rule)', () => {
+    const arr = [1, 3, 3, 5];
+    expect(insertSorted(arr, 3)).toBe(1);
+    expect(arr).toEqual([1, 3, 3, 3, 5]);
+  });
+
+  it('building an array via repeated insertSorted stays sorted regardless of insertion order', () => {
+    const arr: number[] = [];
+    [4, 1, 3, 0, 2].forEach((v) => insertSorted(arr, v));
+    expect(arr).toEqual([0, 1, 2, 3, 4]);
+  });
+});

--- a/tests/radar-player-load-bootstrap.test.ts
+++ b/tests/radar-player-load-bootstrap.test.ts
@@ -1,0 +1,116 @@
+// Tests for _afterFrameInserted / _markRemainingFailed — the init-loop
+// bootstrap logic extracted while fixing issue #246 (radar init loaded the
+// farthest-future forecast frame before "now" for forecast-heavy configs).
+//
+// Frames no longer always load in strict newest-to-oldest order (see
+// buildLoadOrder), so a newly-loaded frame can land at any position in
+// _loadedSlots, not just the front — these tests exercise the real
+// position-aware bootstrap/shift logic directly, rather than hand-copying
+// it into the test (the anti-pattern this repo hit in PR #216).
+//
+// Follows the "stub Leaflet, test the helpers" convention.
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('leaflet', () => {
+  class Layer {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as unknown as { WMS: typeof WMS }).WMS = WMS;
+  class Control {
+    constructor(_opts?: unknown) { void _opts; }
+  }
+  const DomUtil = { create: vi.fn(() => ({ style: {}, classList: { add: vi.fn() } })) };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn() };
+  return {
+    Layer, TileLayer, Control, DomUtil, DomEvent,
+    default: { Layer, TileLayer, Control, DomUtil, DomEvent },
+  };
+});
+
+import { RadarPlayer } from '../src/radar-player';
+import type { WeatherRadarCardConfig } from '../src/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function makePlayer(): RadarPlayer {
+  const map = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getZoom: () => 7,
+    getSize: () => ({ x: 600, y: 400 }),
+    getPane: vi.fn(),
+    createPane: vi.fn(() => ({ style: {} })),
+    getContainer: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0 }) }),
+  } as any;
+  const shadowRoot = { getElementById: () => null, host: {} } as any;
+  return new RadarPlayer({
+    map,
+    shadowRoot,
+    getConfig: () => ({ type: 'custom:weather-radar-card' } as WeatherRadarCardConfig),
+    rainviewerLimiter: {} as any,
+    noaaLimiter: {} as any,
+    dwdLimiter: {} as any,
+  });
+}
+
+describe('_afterFrameInserted', () => {
+  it('does nothing until 2 frames are loaded', () => {
+    const p = makePlayer() as any;
+    p._startLoop = vi.fn();
+    p._loadedSlots = [3];
+    p._afterFrameInserted(1, 0);
+    expect(p._radarReady).toBe(false);
+    expect(p._startLoop).not.toHaveBeenCalled();
+  });
+
+  it('starts the loop at "now"\'s position the first time 2 frames are ready', () => {
+    const p = makePlayer() as any;
+    p._startLoop = vi.fn();
+    p._loadedSlots = [2, 3]; // second frame (index 2) just inserted ahead of the first (3)
+    p._nowFrameIndex = 3;
+    p._afterFrameInserted(1, 0); // prevSlotCount=1 (< 2) -> "first time reaching 2" branch
+    expect(p._startLoop).toHaveBeenCalledWith(1); // position of nowFrameIndex(3) in [2, 3]
+    expect(p._radarReady).toBe(true);
+  });
+
+  it('shifts _currentSlot/_prev1Slot when the new frame inserts at or before their position', () => {
+    const p = makePlayer() as any;
+    p._loadedSlots = [1, 2, 4]; // a frame was just inserted at position 1 (value 2)
+    p._currentSlot = 2;
+    p._prev1Slot = 1;
+    p._afterFrameInserted(2, 1); // prevSlotCount=2 (>=2) -> shift branch, insertPos=1
+    expect(p._currentSlot).toBe(3); // 1 <= 2 -> shifted
+    expect(p._prev1Slot).toBe(2);  // 1 <= 1 -> shifted
+  });
+
+  it('does not shift _currentSlot/_prev1Slot when the new frame inserts after their position', () => {
+    const p = makePlayer() as any;
+    p._loadedSlots = [0, 1, 3]; // a frame was just inserted at the tail, position 2 (value 3)
+    p._currentSlot = 0;
+    p._prev1Slot = 0;
+    p._afterFrameInserted(2, 2);
+    expect(p._currentSlot).toBe(0);
+    expect(p._prev1Slot).toBe(0);
+  });
+});
+
+describe('_markRemainingFailed', () => {
+  it('marks only the not-yet-attempted frames (order[fromIdx..]) as failed', () => {
+    const p = makePlayer() as any;
+    const order = [2, 3, 4, 1, 0]; // e.g. nowIndex=2 in a 5-frame mixed config
+    p._segEls = [0, 1, 2, 3, 4].map(() => ({ style: {} as Record<string, string> }));
+    // Raw indices 2 and 3 are order[0]/order[1] — already attempted and
+    // loaded before the failure. The rest (4, 1, 0) haven't been attempted.
+    p._frameStatuses = ['empty', 'empty', 'loaded', 'loaded', 'empty'];
+
+    p._markRemainingFailed(order, 2); // order[2..] = [4, 1, 0] — everything after the failure
+
+    expect(p._frameStatuses[4]).toBe('failed');
+    expect(p._frameStatuses[1]).toBe('failed');
+    expect(p._frameStatuses[0]).toBe('failed');
+    // Already-attempted frames (order[0], order[1] = 2, 3) are untouched.
+    expect(p._frameStatuses[2]).toBe('loaded');
+    expect(p._frameStatuses[3]).toBe('loaded');
+  });
+});

--- a/tests/start-paused.test.ts
+++ b/tests/start-paused.test.ts
@@ -32,7 +32,7 @@ vi.mock('leaflet', () => {
   };
 });
 
-import { RadarPlayer, type RadarFrame } from '../src/radar-player';
+import { RadarPlayer, type RadarFrame, insertSorted } from '../src/radar-player';
 import { RadarToolbar } from '../src/radar-toolbar';
 import type { WeatherRadarCardConfig } from '../src/types';
 
@@ -95,19 +95,16 @@ describe('RadarPlayer with start_paused (run = false before init)', () => {
     p._loadedSlots = [1];
     p._currentSlot = 0;
     p._prev1Slot = 0;
+    p._nowFrameIndex = 1;
     p._radarImage = [fakeLayer(), fakeLayer()];
     p._radarPaths = frames(1000, 1600);
 
-    // Simulate the second frame loading — the two-frames-ready branch
-    // in _initRadarBody now calls _startLoop unconditionally.
-    // _startLoop sets _currentSlot, calls _showSlot (setting _prev1Slot),
-    // then _scheduleNext returns immediately when !this.run.
+    // Simulate the second (older) frame loading via the real insertion +
+    // bootstrap logic _initRadarBody uses, rather than hand-copying it —
+    // a hand-copy here can't catch a regression in the real methods.
     const prevSlotCount = p._loadedSlots.length;
-    p._loadedSlots.unshift(0);
-
-    if (p._loadedSlots.length >= 2 && prevSlotCount < 2) {
-      p._startLoop(p._loadedSlots.length - 1);
-    }
+    const insertPos = insertSorted(p._loadedSlots, 0);
+    p._afterFrameInserted(prevSlotCount, insertPos);
 
     expect(p._startLoop).toHaveBeenCalledWith(1);
   });


### PR DESCRIPTION
## Summary
- `_initRadarBody` always loaded the highest array index first, which is "now" only when `forecast_minutes: 0`. For forecast-heavy configs (e.g. `past_minutes: 0, forecast_minutes: 60`), index 0 is "now" and the old order loaded the farthest-future frame first, crawling backward toward "now" last.
- Load order now starts at `_nowFrameIndex` and fans forward through forecast frames, then backward through past frames (`buildLoadOrder`). `_loadedSlots` insertion, the playback-bootstrap/shift logic, and the failure-marking path are reworked (`insertSorted`, `_afterFrameInserted`, `_markRemainingFailed`) since loads can now land anywhere, not just the front.
- Also fixes a latent staleness issue in `_scheduleNext` this change made reachable: `isLoopBack` was computed at schedule time and could go stale if `_loadedSlots` grew before the timer fired, occasionally picking the wrong snap-vs-crossfade transition. Now recomputed fresh at fire time.
- Verified against a live DWD server with the reporter's exact config: first tile requests are for the "now" timestamp, not the +60min forecast frame.

Closes #246

## Test plan
- [x] `npm test` (730 tests, incl. 17 new covering the load-order/bootstrap logic)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Live-verified in the local HA testbed against the real DWD server with `past_minutes: 0, forecast_minutes: 60` — confirmed via network trace that "now" loads before any forecast frame