### PR TITLE
fix(radar-player): stop the loop before _updateRadar shifts frame indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The periodic background refresh could corrupt the current playback position, causing the timeline to jump backward on loop and skip-back to jump to "Latest" instead of the previous frame.** Every ~5-6 min refresh renumbers frame indices and temporarily shrinks the loaded-frame list while the new frame's tiles load, but didn't stop the running animation timer or adjust the current position for the shift first — a tick or button press landing in that window read a stale position against the shrunk list, landing on an arbitrary wrapped frame. ([#249](https://github.com/jpettitt/weather-radar-card/issues/249))
+
 ## [3.8.0-beta2] - 2026-08-21
 
 > **Beta pre-release.** Fixes forecast-heavy configs loading their farthest-future frame before "now". Continues the 3.8.0 beta line — drop-in upgrade from 3.8.0-beta1, no config changes required.

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -2632,6 +2632,16 @@ export class RadarPlayer {
     }
     const frameCount = this._configFrameCount;
 
+    // Stop the loop before renumbering frame indices below — otherwise an
+    // already-armed animation tick can fire mid-shift against a
+    // temporarily-shrunk _loadedSlots (frameCount -> frameCount-1 until
+    // the new frame settles) using a now-stale _currentSlot, landing on
+    // an arbitrary wrapped position instead of continuing smoothly.
+    // _stopLoop's _settleVisibility runs first, against the still-valid
+    // pre-shift state. _startLoop() below re-arms a fresh generation
+    // once the new frame is ready.
+    this._stopLoop();
+
     const newLayer = this._createLayer(latestFrame);
     newLayer.addTo(this._map);
     const newTime = this._getTimeString(latestFrame.time * 1000);
@@ -2639,6 +2649,11 @@ export class RadarPlayer {
     // create or shift on refresh; the no-data geometry doesn't change.
 
     this._radarImage[0]?.remove();
+    // _loadedSlots holds raw frame indices; if frame 0 was loaded it's
+    // about to be dropped below, and every position after it shifts down
+    // by one — track that so _currentSlot/_prev1Slot keep pointing at
+    // the same frame instead of going stale.
+    const droppedOldest = this._loadedSlots[0] === 0;
     // _radarPaths shifts alongside the others because nearestFrameIndex() reads .time off it.
     for (let i = 0; i < frameCount - 1; i++) {
       this._radarImage[i] = this._radarImage[i + 1];
@@ -2651,6 +2666,10 @@ export class RadarPlayer {
     this._radarPaths[frameCount - 1] = latestFrame;
     this._lastFrameRefreshAt = Date.now();
     this._loadedSlots = this._loadedSlots.map(fi => fi - 1).filter(fi => fi >= 0);
+    if (droppedOldest) {
+      this._currentSlot = Math.max(0, this._currentSlot - 1);
+      if (this._prev1Slot >= 0) this._prev1Slot = Math.max(0, this._prev1Slot - 1);
+    }
     // Shift motion-compensation state alongside the radar frames.
     // The old frame 0 is dropped, so old motion[1] (which described
     // the 0→1 transition) is also dropped — its predecessor no

--- a/tests/radar-player-update-radar.test.ts
+++ b/tests/radar-player-update-radar.test.ts
@@ -1,0 +1,208 @@
+// Tests for _updateRadar (the periodic ~5-min background data refresh) —
+// issue #249: "timeline drifts backward on every loop" / skip-back jumps
+// to the wrong frame.
+//
+// Root cause: _updateRadar synchronously renumbers every frame index and
+// shrinks _loadedSlots by one (dropping the oldest frame) before the new
+// frame's tiles have settled, but never cancelled the already-running
+// animation-loop timer first. A tick from that stale timer could fire
+// mid-shift, computing (_currentSlot + 1) % _loadedSlots.length against a
+// now-stale _currentSlot and a temporarily-shrunk array — landing on an
+// arbitrary wrapped position instead of continuing smoothly. Confirmed by
+// reproducing it against the real (pre-fix) _updateRadar before fixing:
+// _currentSlot was left at its pre-shift value (out of range for the
+// shrunk array) until the new frame's load event eventually reset it.
+//
+// Fix: _stopLoop() before the shift (cancels/regenerations the pending
+// timer), plus synchronously decrementing _currentSlot/_prev1Slot when
+// the oldest frame is actually dropped — mirroring the position-aware
+// shift already used by _afterFrameInserted for the init loop. The
+// recovery listener stays a raw `layer.once('load', ...)` (unchanged) —
+// _updateRadar's synchronous portion still returns without waiting for
+// the new frame to settle, matching every existing test's assumptions.
+//
+// Follows the "stub Leaflet, test the helpers" convention.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('leaflet', () => {
+  class Layer {}
+  class TileLayer {}
+  class WMS {}
+  (TileLayer as unknown as { WMS: typeof WMS }).WMS = WMS;
+  class Control {
+    constructor(_opts?: unknown) { void _opts; }
+  }
+  const DomUtil = { create: vi.fn(() => ({ style: {}, classList: { add: vi.fn() } })) };
+  const DomEvent = { disableClickPropagation: vi.fn(), on: vi.fn() };
+  return {
+    Layer, TileLayer, Control, DomUtil, DomEvent,
+    default: { Layer, TileLayer, Control, DomUtil, DomEvent },
+  };
+});
+
+import { RadarPlayer } from '../src/radar-player';
+import type { WeatherRadarCardConfig } from '../src/types';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function fakeLayer(label: string): any {
+  const container = { style: {} as Record<string, string>, offsetHeight: 0 };
+  const listeners: Record<string, (() => void)[]> = {};
+  return {
+    addTo: vi.fn(),
+    remove: vi.fn(),
+    once: vi.fn((ev: string, cb: () => void) => {
+      (listeners[ev] ??= []).push(cb);
+    }),
+    off: vi.fn((ev: string, cb: () => void) => {
+      listeners[ev] = (listeners[ev] ?? []).filter(f => f !== cb);
+    }),
+    on: vi.fn(),
+    getContainer: () => container,
+    _tileFailed: 0,
+    _label: label,
+    _fireLoad: () => { listeners['load']?.forEach(cb => cb()); },
+  };
+}
+
+function makePlayer(cfg: Partial<WeatherRadarCardConfig> = {}): RadarPlayer {
+  const map = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getZoom: () => 7,
+    getSize: () => ({ x: 600, y: 400 }),
+    getPane: vi.fn(),
+    createPane: vi.fn(() => ({ style: {} })),
+    getContainer: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0 }) }),
+  } as any;
+  const shadowRoot = { getElementById: () => null, host: {} } as any;
+  return new RadarPlayer({
+    map,
+    shadowRoot,
+    getConfig: () => ({ type: 'custom:weather-radar-card', ...cfg } as WeatherRadarCardConfig),
+    rainviewerLimiter: {} as any,
+    noaaLimiter: {} as any,
+    dwdLimiter: {} as any,
+  });
+}
+
+const NOW_SEC = 1_800_000_000;
+const FRAME_COUNT = 13;
+const STRIDE_SEC = 5 * 60;
+
+function seedSteadyState(p: any) {
+  const mkFrames = (endSec: number) => Array.from({ length: FRAME_COUNT }, (_, i) => ({
+    time: endSec + (i - (FRAME_COUNT - 1)) * STRIDE_SEC,
+    path: '',
+  }));
+  p._radarPaths = mkFrames(NOW_SEC);
+  p._radarImage = Array.from({ length: FRAME_COUNT }, (_, i) => fakeLayer(`init-${i}`));
+  p._radarTime = Array.from({ length: FRAME_COUNT }, (_, i) => ({ date: 'd', time: `frame-${i}` }));
+  p._frameStatuses = Array.from({ length: FRAME_COUNT }, () => 'loaded');
+  p._loadedSlots = Array.from({ length: FRAME_COUNT }, (_, i) => i);
+  p._configFrameCount = FRAME_COUNT;
+  p._radarReady = true;
+  p._nowFrameIndex = FRAME_COUNT - 1;
+  p._currentSlot = FRAME_COUNT - 1;
+  p._prev1Slot = FRAME_COUNT - 1;
+  p._frameSnapshot = new Array(FRAME_COUNT).fill(null);
+  p._frameSnapshotNz = new Array(FRAME_COUNT).fill(0);
+  p._frameMotion = new Array(FRAME_COUNT).fill(null);
+  p.navPaused = false;
+  p.viewPaused = false;
+  return mkFrames;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_SEC * 1000);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('_updateRadar — animation-loop race (issue #249)', () => {
+  it('a stale in-flight tick from before the refresh cannot corrupt _currentSlot mid-shift', async () => {
+    const p = makePlayer({ frame_delay: 100, restart_delay: 200 }) as any;
+    const mkFrames = seedSteadyState(p);
+    p.run = true;
+    p._startLoop(p._currentSlot); // arms a real _scheduleNext timer
+
+    p._fetchPaths = vi.fn().mockResolvedValue(mkFrames(NOW_SEC + STRIDE_SEC));
+    let capturedNewLayer: any = null;
+    p._createLayer = vi.fn(() => { capturedNewLayer = fakeLayer('refresh-new'); return capturedNewLayer; });
+    p._setLayerZ = vi.fn();
+
+    const updatePromise = p._updateRadar();
+    await vi.advanceTimersByTimeAsync(0); // let _fetchPaths resolve and the sync shift run
+
+    // Right after the shift, _currentSlot must already be a valid
+    // position in the (temporarily shrunk) _loadedSlots.
+    expect(p._currentSlot).toBeLessThan(p._loadedSlots.length);
+    expect(p._currentSlot).toBeGreaterThanOrEqual(0);
+
+    // Advance past where the old (pre-refresh) tick would have fired —
+    // it must be a no-op now (stale generation), not a corrupting jump.
+    await vi.advanceTimersByTimeAsync(350);
+    expect(p._currentSlot).toBeLessThan(p._loadedSlots.length);
+    expect(p._loadedSlots.length).toBe(FRAME_COUNT - 1); // still mid-refresh
+
+    capturedNewLayer._fireLoad();
+    await updatePromise;
+
+    expect(p._loadedSlots).toEqual(Array.from({ length: FRAME_COUNT }, (_, i) => i));
+    expect(p._currentSlot).toBe(FRAME_COUNT - 1); // back on "now"
+  });
+
+  it('_currentSlot/_prev1Slot decrement in step with the dropped oldest frame even while paused', async () => {
+    const p = makePlayer() as any;
+    const mkFrames = seedSteadyState(p);
+    p.run = false; // start_paused-style: no animation timer to race
+
+    p._fetchPaths = vi.fn().mockResolvedValue(mkFrames(NOW_SEC + STRIDE_SEC));
+    let capturedNewLayer: any = null;
+    p._createLayer = vi.fn(() => { capturedNewLayer = fakeLayer('refresh-new'); return capturedNewLayer; });
+    p._setLayerZ = vi.fn();
+
+    const updatePromise = p._updateRadar();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Paused, mid-refresh: _currentSlot must still track "now" at its
+    // new (shifted) position, not the stale pre-shift value.
+    expect(p._currentSlot).toBe(FRAME_COUNT - 2);
+    expect(p._prev1Slot).toBe(FRAME_COUNT - 2);
+
+    capturedNewLayer._fireLoad();
+    await updatePromise;
+
+    expect(p._currentSlot).toBe(FRAME_COUNT - 1);
+  });
+
+  it('skipBack from "Latest" mid-refresh steps to the previous frame, not back to "Latest" itself', async () => {
+    // Covers the report's second symptom: paused on "Latest", skip-back
+    // appeared to jump to the end (i.e. no visible change) instead of
+    // stepping back. Reproducible whenever skipBack runs while
+    // _currentSlot is stale — before this fix, a press landing in the
+    // mid-shift window would see _currentSlot still at its pre-shift
+    // value (frameCount - 1, out of range for the shrunk array), so
+    // (currentSlot - 1 + n) % n wrapped to n - 1 — "Latest" again.
+    const p = makePlayer() as any;
+    const mkFrames = seedSteadyState(p);
+    p.run = false;
+
+    p._fetchPaths = vi.fn().mockResolvedValue(mkFrames(NOW_SEC + STRIDE_SEC));
+    p._createLayer = vi.fn(() => fakeLayer('refresh-new'));
+    p._setLayerZ = vi.fn();
+
+    void p._updateRadar();
+    await vi.advanceTimersByTimeAsync(0); // mid-refresh: _loadedSlots shrunk, not yet recovered
+
+    p.skipBack();
+
+    // Previous frame relative to the shifted "now" position, never a
+    // no-op wrap back to the last position.
+    expect(p._currentSlot).toBe(FRAME_COUNT - 3);
+  });
+});


### PR DESCRIPTION
## Summary
- `_updateRadar`'s periodic (~5-6 min) refresh synchronously renumbers every frame index and shrinks `_loadedSlots` by one while waiting for the new frame's tiles to settle, but never stopped the already-running animation timer or adjusted `_currentSlot`/`_prev1Slot` for the shift first.
- A tick (or a skip-back press) landing in that window read a stale `_currentSlot` against the temporarily-shrunk array, landing on an arbitrary wrapped position — reported as the timeline drifting backward on loop, and skip-back jumping to "Latest" instead of the previous frame.
- Fix: `_stopLoop()` before the shift cancels/regenerations the in-flight timer, and `_currentSlot`/`_prev1Slot` are synchronously decremented when the oldest frame is actually dropped — mirroring the position-aware shift already used by `_afterFrameInserted` for the init loop.

Closes #249

## Test plan
- [x] `npm test` (733 tests, incl. 3 new — confirmed to fail against the pre-fix code, including skipBack landing on n-1 of the shrunk array, exactly "jumps to Latest")
- [x] `npm run lint`
- [x] `npm run build`