### PR TITLE
release: 3.8.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0-beta3] - 2026-08-23
+
+> **Beta pre-release.** Fixes a periodic-refresh race that could corrupt playback position (timeline jumping backward on loop, skip-back jumping to "Latest"). Continues the 3.8.0 beta line — drop-in upgrade from 3.8.0-beta2, no config changes required.
+
 ### Fixed
 
 - **The periodic background refresh could corrupt the current playback position, causing the timeline to jump backward on loop and skip-back to jump to "Latest" instead of the previous frame.** Every ~5-6 min refresh renumbers frame indices and temporarily shrinks the loaded-frame list while the new frame's tiles load, but didn't stop the running animation timer or adjust the current position for the shift first — a tick or button press landing in that window read a stale position against the shrunk list, landing on an arbitrary wrapped frame. ([#249](https://github.com/jpettitt/weather-radar-card/issues/249))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0-beta2",
+  "version": "3.8.0-beta3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.8.0-beta2",
+      "version": "3.8.0-beta3",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0-beta2",
+  "version": "3.8.0-beta3",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [


### PR DESCRIPTION
## Summary
- Version bump to 3.8.0-beta3, promoting the Unreleased changelog section.
- Fixes a periodic-refresh race that could corrupt playback position — timeline jumping backward on loop, skip-back jumping to "Latest" ([#249](https://github.com/jpettitt/weather-radar-card/issues/249)).

## Test plan
- [x] `npm test` (733 tests)
- [x] `npm run lint`
- [x] `npm run build`