### PR TITLE
release: 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-08-26
+
+> **Stable release.** Graduates the 3.8.0 line (themeable progress-bar colors, HA-locale-aware timestamps and wildfire formatting, plus two playback-position corruption fixes) to stable. Drop-in upgrade from 3.7.3 — no config changes required. The entries below are what changed since `3.7.3`.
+
+### Added
+
+- **Progress bar colors are now themeable via YAML** — `progress_bar_background_color`, `progress_bar_active_color`, and `progress_bar_now_color` override the built-in light/dark palette for the timeline's at-rest, currently-playing, and wall-clock "now" marker colors. Loading/failed status colors stay fixed since they signal real state, not decoration. YAML-only (matches the existing `dwd_wind_flow_color_*`/`wildfire_color` convention) — not exposed in the visual editor. ([#233](https://github.com/jpettitt/weather-radar-card/issues/233))
+
+### Changed
+
+- **Wildfire popup now shows area in acres or hectares to match your Home Assistant unit system**, instead of always showing NIFC's raw acres. Metric users get hectares (not km² — hectares is the international convention for wildfire/land area, matching Australia's RFS, Canada's CIFFC, and Europe's EFFIS). The number itself, and the discovery date below it, now also follow your HA locale (thousands separator / date ordering) instead of guessing from the browser. The popup label changed from "Acres" to "Area" to match.
+
+### Fixed
+
+- **Timestamps now follow Home Assistant's own Time format setting instead of guessing from the browser.** The radar timeline and NWS alert Effective/Expires times used `Intl.DateTimeFormat`/`Date#toLocaleString` with the browser's ambient locale to decide 12h vs 24h — an unreliable signal, since many users run an en-US browser/OS language regardless of where they live, and even an explicit OS 24-hour override often isn't honoured by `Intl`'s locale resolution. Both now defer to `hass.locale.time_format` (Settings → General) via `custom-card-helpers`' `formatTime`/`formatDateTime` — the same helpers HA's own frontend uses — falling back to the previous browser-locale behavior when unavailable. ([#239](https://github.com/jpettitt/weather-radar-card/issues/239))
+- **Radar init no longer loads the farthest-future forecast frame before "now" on forecast-heavy configs.** The initial load always fetched frames highest-array-index-first, which coincided with "now" only when there was little/no `forecast_minutes` — for a config like `past_minutes: 0, forecast_minutes: 60`, "now" was index 0 and loaded dead last, so the card showed an hour-ahead forecast frame first and took a full sequential pass through every forecast frame before showing current conditions. The load order now always starts at "now" and fans forward through any forecast frames, then backward through any past frames — unchanged for today's common past-only configs. ([#246](https://github.com/jpettitt/weather-radar-card/issues/246))
+- **The periodic background refresh could corrupt the current playback position, causing the timeline to jump backward on loop and skip-back to jump to "Latest" instead of the previous frame.** Every ~5-6 min refresh renumbers frame indices and temporarily shrinks the loaded-frame list while the new frame's tiles load, but didn't stop the running animation timer or adjust the current position for the shift first — a tick or button press landing in that window read a stale position against the shrunk list, landing on an arbitrary wrapped frame. ([#249](https://github.com/jpettitt/weather-radar-card/issues/249))
+- **Two related edge cases hardened during pre-release review.** A source that fails to publish a fresh "now" frame for several consecutive refresh cycles no longer freezes the display on an invalid position; and if the exact frame you're watching gets pruned as a duplicate, playback now falls back to whichever frame is nearest "now" instead of jumping to the newest (potentially farthest-future) frame.
+
 ## [3.8.0-beta3] - 2026-08-23
 
 > **Beta pre-release.** Fixes a periodic-refresh race that could corrupt playback position (timeline jumping backward on loop, skip-back jumping to "Latest"). Continues the 3.8.0 beta line — drop-in upgrade from 3.8.0-beta2, no config changes required.

--- a/README.md
+++ b/README.md
@@ -19,35 +19,34 @@ Full-screen capture with every feature enabled — radar with motion compensatio
 
 [![Watch the demo on YouTube](https://img.youtube.com/vi/xfbZRElOi0o/maxresdefault.jpg)](https://youtu.be/xfbZRElOi0o)
 
-## What's new in 3.7 (current stable)
+## What's new in 3.8 (current stable)
 
 **Headline features:**
 
+- **Themeable progress-bar colors** — `progress_bar_background_color`, `progress_bar_active_color`, and `progress_bar_now_color` override the timeline's built-in light/dark palette via YAML, to match your dashboard theme. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
+- **Timestamps follow Home Assistant's own Time format setting** — the radar timeline and NWS alert times defer to your HA profile's 12h/24h preference (Settings → General) instead of guessing from the browser locale. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
+
+**Also in 3.8 — fixes:**
+
+- **Wildfire popup area and discovery date now follow your HA unit system and locale** — hectares for metric users instead of always showing NIFC's raw acres, and locale-aware date ordering. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
+- **Forecast-heavy configs no longer load the farthest-future frame before "now"** — for a config like `past_minutes: 0, forecast_minutes: 60`, the initial load now always starts at "now" and fans outward, instead of loading highest-index-first. ([3.8.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta2))
+- **Fixed a periodic-refresh race that could corrupt playback position** — the timeline drifting backward on loop, or skip-back jumping to "Latest" instead of the previous frame. ([3.8.0-beta3](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta3))
+
+For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
+
+## What's new in 3.7
+
 - **Smooth motion** — opt-in `motion_compensation: true`. During each frame transition, rain slides along its actual direction of travel instead of crossfading in place, so the loop reads as one continuously drifting rain field. Pyramidal Lucas-Kanade optical flow, runs in a Web Worker, source-agnostic across DWD / RainViewer / NOAA. Built on top of [@genericJE](https://github.com/genericJE)'s [#156](https://github.com/jpettitt/weather-radar-card/pull/156). Pairs naturally with `smooth_animation`. ([3.7.0-alpha2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha2))
 - **Adjustable playback speed** — toolbar button cycles ¼× / ½× / 1× / 2× / 4×; editor dropdown sets the YAML default. Optional per-user persistence via the `viewer_layer_control` admin opt-in: each viewer's chosen speed follows them across browsers and devices. Contributed by [@genericJE](https://github.com/genericJE). ([3.7.0-alpha1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha1))
-
-**Also in 3.7 — stability and performance:**
-
 - **Canvas rendering for lightning and hazard overlays** — strikes, NWS alert polygons, and wildfire perimeters paint to canvas instead of one DOM node per item. Identical visuals and clickability (strike clicks select the most recent within 10 px); soak-validated during live storms at 10,000 simultaneous strikes with the page fully responsive. ([3.7.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta1))
 - **Stability wave** — full-project code-review remediation: refresh/state races fixed (long-running dashboards no longer accumulate duplicate frames), DWD coverage clipping + single shared boundary mask, exponential backoff on alert/wildfire fetch failures, bounded caches, antimeridian fixes for Alaska. ([3.7.0-alpha3](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha3))
 - **NOAA radar rebuilt on NCEP's opengeo GeoServer** (the backend radar.weather.gov itself runs on) — the newest frame is now **~2 minutes behind real time instead of 15–25**, every frame is a distinct radar scan, and a new **Frame interval** dropdown picks 2 / 5 / 10-minute loop density. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
 - **"Latest" replaces "Now"** on the newest-frame label — radar frames lag real time by source (NOAA ~2 min, DWD ~5 min, RainViewer ~1–2 min), so the label no longer overstates freshness. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
 - **Translations completed** for all 3.7 editor strings across the card's 11 languages.
 
-For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
-
-## What's new in 3.6
-
-- **Real-time lightning strikes** when the [Blitzortung integration](https://github.com/mrk-its/homeassistant-blitzortung) is installed — bolt + pulse for first 30 s, then a coloured + sign on a two-pane outline-vs-fill split (dense storm clusters read clean instead of black-blob). Card-side max-age cap defaults to 30 min. ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
-- **Wind overlay** — barbs, arrows, animated streamlines from DWD's ICON-D2 model. Bulk WCS fetch with 60 s coalescing cache, zoom-aware streamlines. See [Hazard & Layer Overlays](https://github.com/jpettitt/weather-radar-card/blob/main/docs/overlays.md#wind). ([3.6.0](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.0))
-- **Wind source registry** — choose `dwd_icon`, `dwd_aicon` (DWD's AI-augmented variant), or `ndfd_wind` (NWS NDFD 2.5 km CONUS / AK / HI / PR). Fresh US installs default to `ndfd_wind` automatically. ([3.6.1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.1))
-- **AbortController** on tile + data fetches — superseded fetches no longer complete on the wire after a pan / zoom / teardown. ([3.6.2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.2))
-- **Tablet-friendly progress-bar touch target** via `progress_bar_touch_height` YAML option, contributed by [@cgjolberg](https://github.com/cgjolberg). ([3.6.4](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.4))
-- **Per-user state framework** (dormant) — `ViewerState` wraps HA's frontend-storage WebSocket API. First user-visible consumer (adjustable playback speed) ships in 3.7. ([3.6.5](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.6.5))
-
 ## Roadmap
 
-Active threads, no specific version commitment — with 3.7 shipped, these target 3.8 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
+Active threads, no specific version commitment — with 3.8 shipped, these target 3.9 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
 
 - **Real-time per-user layer visibility control panel** — UI for toggling individual overlays in real time. Persistence framework already shipped (3.6.5); first consumer shipped (playback speed in 3.7.0-alpha1); the on-map panel itself is the remaining piece. Full design in [docs/layer-control-design.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/layer-control-design.md).
 - **Additional wind sources** — Open-Meteo for global coverage, ICON pressure levels for upper-air wind, regional finer-than-ICON-D2 sources (AROME, MEPS, HRRR). Tiers and trade-offs documented in [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md).

--- a/docs/animation.md
+++ b/docs/animation.md
@@ -350,17 +350,37 @@ longer than the visible-refresh interval.
 
 ## Frame loading sequence
 
-Frames are loaded newest-first. As each frame settles
-(`layerSettled`):
+Frames load starting at "now" (`buildLoadOrder`), fanning forward
+through any forecast frames and then backward through any past
+frames — not always newest-first. For a past-only config `_nowFrameIndex`
+is already the newest frame, so this degenerates to the old
+newest-first order; it's forecast-heavy configs (little/no
+`past_minutes`) where "now" sits near index 0 that this differs, so
+"now" always loads (and is shown) first regardless of the past/forecast
+split (issue #246).
+
+As each frame settles (`layerSettled`):
 
 1. Its outer container starts at `opacity: 0`.
-2. The very first frame to load is shown as a static preview
-   (`opacity: _activeOpacity`) while older frames load in the background.
-3. Once two frames are loaded, `_startLoop(n-1)` starts the animation
-   at the newest slot so the preview continues without a flash.
-4. Each subsequent older frame that loads causes `_currentSlot++` to
-   keep the index pointing at the same frame (since `unshift` shifts
-   all indices up by 1).
+2. The very first frame to load — always "now", per the load order
+   above — is shown as a static preview (`opacity: _activeOpacity`)
+   while the rest load in the background.
+3. Loaded frames are inserted into `_loadedSlots` at their sorted
+   position (`insertSorted`), not blindly prepended — arrival order is
+   no longer strictly descending. Once two frames are loaded,
+   `_startLoop(indexOf(_nowFrameIndex))` starts the animation at "now"
+   so the preview continues without a flash.
+4. Each subsequent frame that loads shifts `_currentSlot`/`_prev1Slot`
+   only if its insertion position is at or before their current
+   position (`_afterFrameInserted`) — inserting after them leaves them
+   untouched, since only positions at-or-after the insertion point
+   actually move.
+5. A load failure aborts the whole sequence and marks every
+   not-yet-attempted frame in the load order as failed
+   (`_markRemainingFailed`) — "not yet attempted" is no longer a
+   contiguous index range once loading walks outward from "now", so
+   this walks the remaining load-order entries rather than counting
+   down from the failed index.
 
 ---
 
@@ -399,7 +419,14 @@ per-source cap table.
 2. `_updateOpacity` (overridden) sets inner tile and tile-container
    opacities to `1` but never touches the outer container.
 3. `_currentSlot` is always a valid index into `_loadedSlots`
-   (`_showSlot` bounds-checks and returns early if not).
+   (`_showSlot` bounds-checks and returns early if not) — maintained
+   across mutations by `_afterFrameInserted`'s insert-position-aware
+   shift during the init loop (`insertSorted` can land a new frame
+   anywhere, not just the front) and by `_updateRadar`'s `droppedOldest`
+   shift, which decrements `_currentSlot`/`_prev1Slot` when a periodic
+   refresh evicts the oldest frame — and which also stops the loop
+   first, so an already-armed animation tick can't fire mid-shift
+   against a temporarily-resized array (issue #249).
 4. `_frameGeneration` is checked after every `await` in `_initRadar`
    and `_updateRadar` to abort stale async chains after teardown.
 5. `_loopGen` is checked at the top of every `_scheduleNext` callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0-beta3",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.8.0-beta3",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0-beta3",
+  "version": "3.8.0",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -1036,7 +1036,12 @@ export class RadarPlayer {
     // Remap _currentSlot / _prev1Slot to the new fi positions so
     // playback resumes on the same content.
     const newCurrent = keptFi.indexOf(currentFi);
-    this._currentSlot = newCurrent >= 0 ? newCurrent : (keptFi.length - 1);
+    // Fall back to nearest-to-now, not "newest" — for a forecast-heavy
+    // config (issue #246) "current" is normally "now", nowhere near the
+    // newest/farthest-future frame, so falling back to newest here would
+    // silently jump playback across the whole forecast window if the
+    // displayed frame happens to be the one deduped away.
+    this._currentSlot = newCurrent >= 0 ? newCurrent : nearestFrameIndex(this._radarPaths, Date.now() / 1000);
     if (prev1Fi >= 0) {
       const newPrev1 = keptFi.indexOf(prev1Fi);
       this._prev1Slot = newPrev1 >= 0 ? newPrev1 : this._currentSlot;
@@ -2402,7 +2407,6 @@ export class RadarPlayer {
       this._setSegment(fi, status);
 
       if (status === 'loaded') {
-        const prevSlotCount = this._loadedSlots.length;
         const insertPos = insertSorted(this._loadedSlots, fi);
 
         // Motion-comp prep: snapshot this frame, then compute the motion
@@ -2454,7 +2458,7 @@ export class RadarPlayer {
           this._prev1Slot = this._loadedSlots.indexOf(fi);
         }
 
-        this._afterFrameInserted(prevSlotCount, insertPos);
+        this._afterFrameInserted(insertPos);
       } else {
         this._markRemainingFailed(order, idx + 1);
         break;
@@ -2501,9 +2505,13 @@ export class RadarPlayer {
   // newest-to-oldest order (see buildLoadOrder), so a new frame can
   // land at any position, not just the front — inserting at `insertPos`
   // only shifts existing positions >= insertPos up by one.
-  private _afterFrameInserted(prevSlotCount: number, insertPos: number): void {
+  private _afterFrameInserted(insertPos: number): void {
     if (this._loadedSlots.length < 2) return;
     this._radarReady = true;
+    // The insert above already happened, so length-1 is the count
+    // before it — i.e. whether this is the 2nd frame ever (bootstrap
+    // the loop) or a later one (shift the existing positions).
+    const prevSlotCount = this._loadedSlots.length - 1;
     if (prevSlotCount >= 2) {
       if (insertPos <= this._currentSlot) this._currentSlot++;
       if (this._prev1Slot >= 0 && insertPos <= this._prev1Slot) this._prev1Slot++;
@@ -2718,9 +2726,17 @@ export class RadarPlayer {
           });
         }
       }
-      // Restart loop at newest frame so new data shows immediately
-      this._currentSlot = this._loadedSlots.length - 1;
-      this._startLoop();
+      // Restart loop at newest frame so new data shows immediately.
+      // Guarded on length: if the newest frame has now failed to load
+      // for enough consecutive refresh cycles that _loadedSlots (which
+      // drops one frame every cycle regardless, via droppedOldest above)
+      // has drained to empty, there's nothing to show — leave state as
+      // is and let the next successful refresh repopulate it, rather
+      // than setting _currentSlot to -1.
+      if (this._loadedSlots.length > 0) {
+        this._currentSlot = this._loadedSlots.length - 1;
+        this._startLoop();
+      }
     });
 
     this._doRadarUpdate = false;

--- a/src/wildfire-layer.ts
+++ b/src/wildfire-layer.ts
@@ -479,9 +479,11 @@ function buildPopupHtml(
   // rationale as the timeline timestamp fix (issue #239): the browser's
   // ambient locale is an unreliable signal, and a misread date ordering
   // here could make a fire look more or less recent than it actually is.
-  const discoveredStr = typeof discovered === 'number'
-    ? (locale ? formatDate(new Date(discovered), locale) : new Date(discovered).toLocaleDateString())
-    : '—';
+  let discoveredStr = '—';
+  if (typeof discovered === 'number') {
+    const d = new Date(discovered);
+    discoveredStr = locale ? formatDate(d, locale) : d.toLocaleDateString();
+  }
 
   // InciWeb URL format: /incident-information/{poo-jurisdictional-unit-lower}-{name-slug}
   // e.g. flfnf-sand-drain. We only render the link when the computed slug

--- a/tests/radar-player-load-bootstrap.test.ts
+++ b/tests/radar-player-load-bootstrap.test.ts
@@ -59,7 +59,7 @@ describe('_afterFrameInserted', () => {
     const p = makePlayer() as any;
     p._startLoop = vi.fn();
     p._loadedSlots = [3];
-    p._afterFrameInserted(1, 0);
+    p._afterFrameInserted(0);
     expect(p._radarReady).toBe(false);
     expect(p._startLoop).not.toHaveBeenCalled();
   });
@@ -69,7 +69,7 @@ describe('_afterFrameInserted', () => {
     p._startLoop = vi.fn();
     p._loadedSlots = [2, 3]; // second frame (index 2) just inserted ahead of the first (3)
     p._nowFrameIndex = 3;
-    p._afterFrameInserted(1, 0); // prevSlotCount=1 (< 2) -> "first time reaching 2" branch
+    p._afterFrameInserted(0); // insertPos=0; _loadedSlots.length-1 (1) < 2 -> "first time reaching 2" branch
     expect(p._startLoop).toHaveBeenCalledWith(1); // position of nowFrameIndex(3) in [2, 3]
     expect(p._radarReady).toBe(true);
   });
@@ -77,10 +77,13 @@ describe('_afterFrameInserted', () => {
   it('shifts _currentSlot/_prev1Slot when the new frame inserts at or before their position', () => {
     const p = makePlayer() as any;
     p._loadedSlots = [1, 2, 4]; // a frame was just inserted at position 1 (value 2)
-    p._currentSlot = 2;
+    // _currentSlot/_prev1Slot are always equal outside _afterFrameInserted's
+    // own execution (_showSlot keeps them in sync) — before this insert,
+    // position 1 (value 4) was current.
+    p._currentSlot = 1;
     p._prev1Slot = 1;
-    p._afterFrameInserted(2, 1); // prevSlotCount=2 (>=2) -> shift branch, insertPos=1
-    expect(p._currentSlot).toBe(3); // 1 <= 2 -> shifted
+    p._afterFrameInserted(1); // insertPos=1; _loadedSlots.length-1 (2) >= 2 -> shift branch
+    expect(p._currentSlot).toBe(2); // 1 <= 1 -> shifted
     expect(p._prev1Slot).toBe(2);  // 1 <= 1 -> shifted
   });
 
@@ -89,7 +92,7 @@ describe('_afterFrameInserted', () => {
     p._loadedSlots = [0, 1, 3]; // a frame was just inserted at the tail, position 2 (value 3)
     p._currentSlot = 0;
     p._prev1Slot = 0;
-    p._afterFrameInserted(2, 2);
+    p._afterFrameInserted(2);
     expect(p._currentSlot).toBe(0);
     expect(p._prev1Slot).toBe(0);
   });

--- a/tests/radar-player-refresh.test.ts
+++ b/tests/radar-player-refresh.test.ts
@@ -231,6 +231,37 @@ describe('_dedupFrames orphan prevention', () => {
   });
 });
 
+describe('_dedupFrames current-frame fallback', () => {
+  it('falls back to nearest-to-now (not "newest") when the currently-displayed frame is deduped away', () => {
+    // Once #246 made "current" normally mean "now" (not "newest") for
+    // forecast-heavy configs, this fallback still assumed "newest" was
+    // always a safe stand-in for "current" — if dedup ever drops exactly
+    // the displayed "now" frame, that would silently jump playback to
+    // the newest/farthest-future frame instead of staying near "now".
+    vi.setSystemTime(1000 * 1000); // "now" lines up with frame 0's time
+
+    const p = makePlayer() as any;
+    const layers = [fakeLayer(), fakeLayer(), fakeLayer(), fakeLayer()];
+    p._radarImage = [...layers];
+    p._radarTime = layers.map((_, i) => ({ date: 'a', time: String(i) }));
+    p._radarPaths = frames(1000, 1600, 2200, 2800);
+    p._frameSnapshot = layers.map(() => new Float32Array(4));
+    p._frameSnapshotNz = [100, 200, 300, 300]; // frame 3 duplicates frame 2 -> dropped
+    p._frameMotion = [null, null, null, null];
+    p._loadedSlots = [0, 1, 2, 3];
+    p._currentSlot = 3; // displaying frame 3 — the one about to be deduped away
+    p._prev1Slot = 3;
+
+    p._dedupFrames();
+
+    expect(p._radarPaths.map((f: RadarFrame) => f.time)).toEqual([1000, 1600, 2200]);
+    // Falls back to the frame nearest "now" (index 0, time 1000) — not
+    // the newest surviving frame (index 2, time 2200).
+    expect(p._currentSlot).toBe(0);
+    expect(p._prev1Slot).toBe(0);
+  });
+});
+
 // ── 4. Single update chain ───────────────────────────────────────────────
 
 describe('_scheduleUpdate single-chain invariant', () => {

--- a/tests/radar-player-update-radar.test.ts
+++ b/tests/radar-player-update-radar.test.ts
@@ -91,24 +91,24 @@ const NOW_SEC = 1_800_000_000;
 const FRAME_COUNT = 13;
 const STRIDE_SEC = 5 * 60;
 
-function seedSteadyState(p: any) {
-  const mkFrames = (endSec: number) => Array.from({ length: FRAME_COUNT }, (_, i) => ({
-    time: endSec + (i - (FRAME_COUNT - 1)) * STRIDE_SEC,
+function seedSteadyState(p: any, frameCount: number = FRAME_COUNT) {
+  const mkFrames = (endSec: number) => Array.from({ length: frameCount }, (_, i) => ({
+    time: endSec + (i - (frameCount - 1)) * STRIDE_SEC,
     path: '',
   }));
   p._radarPaths = mkFrames(NOW_SEC);
-  p._radarImage = Array.from({ length: FRAME_COUNT }, (_, i) => fakeLayer(`init-${i}`));
-  p._radarTime = Array.from({ length: FRAME_COUNT }, (_, i) => ({ date: 'd', time: `frame-${i}` }));
-  p._frameStatuses = Array.from({ length: FRAME_COUNT }, () => 'loaded');
-  p._loadedSlots = Array.from({ length: FRAME_COUNT }, (_, i) => i);
-  p._configFrameCount = FRAME_COUNT;
+  p._radarImage = Array.from({ length: frameCount }, (_, i) => fakeLayer(`init-${i}`));
+  p._radarTime = Array.from({ length: frameCount }, (_, i) => ({ date: 'd', time: `frame-${i}` }));
+  p._frameStatuses = Array.from({ length: frameCount }, () => 'loaded');
+  p._loadedSlots = Array.from({ length: frameCount }, (_, i) => i);
+  p._configFrameCount = frameCount;
   p._radarReady = true;
-  p._nowFrameIndex = FRAME_COUNT - 1;
-  p._currentSlot = FRAME_COUNT - 1;
-  p._prev1Slot = FRAME_COUNT - 1;
-  p._frameSnapshot = new Array(FRAME_COUNT).fill(null);
-  p._frameSnapshotNz = new Array(FRAME_COUNT).fill(0);
-  p._frameMotion = new Array(FRAME_COUNT).fill(null);
+  p._nowFrameIndex = frameCount - 1;
+  p._currentSlot = frameCount - 1;
+  p._prev1Slot = frameCount - 1;
+  p._frameSnapshot = new Array(frameCount).fill(null);
+  p._frameSnapshotNz = new Array(frameCount).fill(0);
+  p._frameMotion = new Array(frameCount).fill(null);
   p.navPaused = false;
   p.viewPaused = false;
   return mkFrames;
@@ -204,5 +204,32 @@ describe('_updateRadar — animation-loop race (issue #249)', () => {
     // Previous frame relative to the shifted "now" position, never a
     // no-op wrap back to the last position.
     expect(p._currentSlot).toBe(FRAME_COUNT - 3);
+  });
+
+  it('never sets _currentSlot to -1 even if the newest frame fails to load for several consecutive cycles', async () => {
+    // Every cycle drops the oldest frame regardless of whether the new
+    // one succeeds (droppedOldest doesn't know in advance) — if the
+    // newest frame specifically keeps failing while nothing is ever
+    // pushed back, _loadedSlots can drain to empty. The load-recovery
+    // callback must not then compute _currentSlot = length - 1 = -1.
+    const SMALL_COUNT = 3;
+    const p = makePlayer() as any;
+    const mkFrames = seedSteadyState(p, SMALL_COUNT);
+    p.run = false;
+
+    for (let cycle = 1; cycle <= SMALL_COUNT; cycle++) {
+      p._fetchPaths = vi.fn().mockResolvedValue(mkFrames(NOW_SEC + cycle * STRIDE_SEC));
+      let layer: any = null;
+      p._createLayer = vi.fn(() => { layer = fakeLayer(`fail-${cycle}`); layer._tileFailed = 1; return layer; });
+      p._setLayerZ = vi.fn();
+
+      const updatePromise = p._updateRadar();
+      await vi.advanceTimersByTimeAsync(0);
+      layer._fireLoad(); // tiles "load" but are marked failed
+      await updatePromise;
+    }
+
+    expect(p._loadedSlots.length).toBe(0);
+    expect(p._currentSlot).toBeGreaterThanOrEqual(0);
   });
 });

--- a/tests/start-paused.test.ts
+++ b/tests/start-paused.test.ts
@@ -102,9 +102,8 @@ describe('RadarPlayer with start_paused (run = false before init)', () => {
     // Simulate the second (older) frame loading via the real insertion +
     // bootstrap logic _initRadarBody uses, rather than hand-copying it —
     // a hand-copy here can't catch a regression in the real methods.
-    const prevSlotCount = p._loadedSlots.length;
     const insertPos = insertSorted(p._loadedSlots, 0);
-    p._afterFrameInserted(prevSlotCount, insertPos);
+    p._afterFrameInserted(insertPos);
 
     expect(p._startLoop).toHaveBeenCalledWith(1);
   });


### PR DESCRIPTION
## Summary
- Pre-release code review fixes: stale README/animation.md docs updated, `_afterFrameInserted`'s redundant param dropped, a wildfire nested-ternary cleanup, an `_updateRadar` guard against `_currentSlot` going to `-1` after several consecutive newest-frame load failures, and a `_dedupFrames` fallback fix (nearest-to-now instead of newest, matching #246's own premise).
- Promotes the 3.8.0 beta line (progress-bar colors, HA-locale timestamps/wildfire formatting, the #246 load-order fix, the #249 refresh-race fix) to stable.

## Test plan
- [x] `npm test` (735 tests, incl. 2 new regression tests for the guard/fallback fixes — both confirmed to fail against the pre-fix code)
- [x] `npm run lint`
- [x] `npm run build`