### PR TITLE
release: 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-08-26
+
+> **Stable release.** CARTO began requiring an API key to avoid a watermark on their free basemap tiles (Light/Voyager/Dark/Satellite) — this release adds a `carto_api_key` option to remove it, plus two new basemap styles that never need a key at all. Drop-in upgrade from 3.8.0 — no config changes required for existing setups.
+
+### Added
+
+- **`carto_api_key` config option** — free CARTO API key (no account needed, [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey/)), appended to CARTO basemap tile requests to remove the "API key required" watermark CARTO now stamps on anonymous tiles. Leaving it unset keeps the previous (watermarked but working) tiles. Exposed in the editor's Map section.
+- **Two new no-key `map_style` options: `Grey` and `GreyDark`** — Esri Light/Dark Grey Canvas basemaps, a genuinely free, no-signup alternative to CARTO for anyone who'd rather not get an API key at all.
+
 ## [3.8.0] - 2026-08-26
 
 > **Stable release.** Graduates the 3.8.0 line (themeable progress-bar colors, HA-locale-aware timestamps and wildfire formatting, plus two playback-position corruption fixes) to stable. Drop-in upgrade from 3.7.3 — no config changes required. The entries below are what changed since `3.7.3`.

--- a/README.md
+++ b/README.md
@@ -19,34 +19,26 @@ Full-screen capture with every feature enabled — radar with motion compensatio
 
 [![Watch the demo on YouTube](https://img.youtube.com/vi/xfbZRElOi0o/maxresdefault.jpg)](https://youtu.be/xfbZRElOi0o)
 
-## What's new in 3.8 (current stable)
+## What's new in 3.9 (current stable)
 
-**Headline features:**
+CARTO began requiring an API key to avoid a watermark on their free basemap tiles (Light/Voyager/Dark/Satellite) — this release adds an option to remove it, plus two new basemap styles that never need a key at all.
+
+- **`carto_api_key` config option** — free CARTO API key (no account needed — [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey/)) removes the watermark. Set it in the editor's Map section or via YAML; leaving it unset keeps the previous (watermarked but working) tiles.
+- **Two new no-key map styles: `Grey` and `GreyDark`** — Esri Light/Dark Grey Canvas basemaps, for anyone who'd rather not sign up for a CARTO key at all.
+
+For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
+
+## What's new in 3.8
 
 - **Themeable progress-bar colors** — `progress_bar_background_color`, `progress_bar_active_color`, and `progress_bar_now_color` override the timeline's built-in light/dark palette via YAML, to match your dashboard theme. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
 - **Timestamps follow Home Assistant's own Time format setting** — the radar timeline and NWS alert times defer to your HA profile's 12h/24h preference (Settings → General) instead of guessing from the browser locale. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
-
-**Also in 3.8 — fixes:**
-
 - **Wildfire popup area and discovery date now follow your HA unit system and locale** — hectares for metric users instead of always showing NIFC's raw acres, and locale-aware date ordering. ([3.8.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta1))
 - **Forecast-heavy configs no longer load the farthest-future frame before "now"** — for a config like `past_minutes: 0, forecast_minutes: 60`, the initial load now always starts at "now" and fans outward, instead of loading highest-index-first. ([3.8.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta2))
 - **Fixed a periodic-refresh race that could corrupt playback position** — the timeline drifting backward on loop, or skip-back jumping to "Latest" instead of the previous frame. ([3.8.0-beta3](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.8.0-beta3))
 
-For the full release history see [CHANGELOG](https://github.com/jpettitt/weather-radar-card/blob/main/CHANGELOG.md).
-
-## What's new in 3.7
-
-- **Smooth motion** — opt-in `motion_compensation: true`. During each frame transition, rain slides along its actual direction of travel instead of crossfading in place, so the loop reads as one continuously drifting rain field. Pyramidal Lucas-Kanade optical flow, runs in a Web Worker, source-agnostic across DWD / RainViewer / NOAA. Built on top of [@genericJE](https://github.com/genericJE)'s [#156](https://github.com/jpettitt/weather-radar-card/pull/156). Pairs naturally with `smooth_animation`. ([3.7.0-alpha2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha2))
-- **Adjustable playback speed** — toolbar button cycles ¼× / ½× / 1× / 2× / 4×; editor dropdown sets the YAML default. Optional per-user persistence via the `viewer_layer_control` admin opt-in: each viewer's chosen speed follows them across browsers and devices. Contributed by [@genericJE](https://github.com/genericJE). ([3.7.0-alpha1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha1))
-- **Canvas rendering for lightning and hazard overlays** — strikes, NWS alert polygons, and wildfire perimeters paint to canvas instead of one DOM node per item. Identical visuals and clickability (strike clicks select the most recent within 10 px); soak-validated during live storms at 10,000 simultaneous strikes with the page fully responsive. ([3.7.0-beta1](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta1))
-- **Stability wave** — full-project code-review remediation: refresh/state races fixed (long-running dashboards no longer accumulate duplicate frames), DWD coverage clipping + single shared boundary mask, exponential backoff on alert/wildfire fetch failures, bounded caches, antimeridian fixes for Alaska. ([3.7.0-alpha3](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-alpha3))
-- **NOAA radar rebuilt on NCEP's opengeo GeoServer** (the backend radar.weather.gov itself runs on) — the newest frame is now **~2 minutes behind real time instead of 15–25**, every frame is a distinct radar scan, and a new **Frame interval** dropdown picks 2 / 5 / 10-minute loop density. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
-- **"Latest" replaces "Now"** on the newest-frame label — radar frames lag real time by source (NOAA ~2 min, DWD ~5 min, RainViewer ~1–2 min), so the label no longer overstates freshness. ([3.7.0-beta2](https://github.com/jpettitt/weather-radar-card/releases/tag/v3.7.0-beta2))
-- **Translations completed** for all 3.7 editor strings across the card's 11 languages.
-
 ## Roadmap
 
-Active threads, no specific version commitment — with 3.8 shipped, these target 3.9 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
+Active threads, no specific version commitment — with 3.9 shipped, these target 3.10 or later. See [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md) for the full backlog with status per item.
 
 - **Real-time per-user layer visibility control panel** — UI for toggling individual overlays in real time. Persistence framework already shipped (3.6.5); first consumer shipped (playback speed in 3.7.0-alpha1); the on-map panel itself is the remaining piece. Full design in [docs/layer-control-design.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/layer-control-design.md).
 - **Additional wind sources** — Open-Meteo for global coverage, ICON pressure levels for upper-air wind, regional finer-than-ICON-D2 sources (AROME, MEPS, HRRR). Tiers and trade-offs documented in [docs/todo.md](https://github.com/jpettitt/weather-radar-card/blob/main/docs/todo.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ All options can be configured using the GUI editor — there is no need to edit 
 | center_latitude               | number / string | **Optional**   | Initial map center latitude — number or entity ID                                                                                                                                                                                                                                                                                                                      | HA instance location                  |
 | center_longitude              | number / string | **Optional**   | Initial map center longitude — number or entity ID                                                                                                                                                                                                                                                                                                                     | HA instance location                  |
 | map_style                     | string          | **Optional**   | Map style (see [Map Style](#map-style))                                                                                                                                                                                                                                                                                                                                | `'Auto'` (follows OS dark/light mode) |
+| carto_api_key                 | string          | **Optional**   | Free CARTO API key (no account needed — see [Map Style](#map-style)) appended to CARTO basemap tile requests. Removes the "API key required" watermark on Light/Voyager/Dark/Satellite tiles. No effect for OSM/Grey/GreyDark.                                                                                                                                         | unset (watermarked anonymous tiles)   |
 | markers                       | list            | **Optional**   | List of map markers (see [Markers](markers.md))                                                                                                                                                                                                                                                                                                                        | none                                  |
 | cluster_markers               | boolean         | **Optional**   | Cluster nearby markers into a badge; tap/click the badge to spiderfy (fan out) individual markers. The tracked marker always renders outside the cluster. Clusters containing a home marker render the home icon with a small superscript count badge.                                                                                                                 | `true`                                |
 | show_snow                     | boolean         | **Optional**   | Include snow in the precipitation display (RainViewer only)                                                                                                                                                                                                                                                                                                            | `false`                               |
@@ -81,18 +82,24 @@ All options can be configured using the GUI editor — there is no need to edit 
 
 ## Map Style
 
-Specifies the base map style. All CARTO-based styles render labels in English only. Use OpenStreetMap for localized labels.
+Specifies the base map style. All CARTO- and Esri-based styles render labels in English only. Use OpenStreetMap for localized labels.
 
-| Value       | Description                                                                                      |
-|-------------|--------------------------------------------------------------------------------------------------|
-| `Auto`      | Follows OS dark/light mode — Dark when system is dark, Light (English) or OSM (other) when light |
-| `Light`     | CARTO Light — English only                                                                       |
-| `Dark`      | CARTO Dark — English only                                                                        |
-| `Voyager`   | CARTO Voyager — English only                                                                     |
-| `Satellite` | ESRI World Imagery — English only                                                                |
-| `OSM`       | OpenStreetMap — labels rendered in local language                                                |
+| Value        | Description                                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------|
+| `Auto`       | Follows OS dark/light mode — Dark when system is dark, Light (English) or OSM (other) when light |
+| `Light`      | CARTO Light — English only                                                                       |
+| `Dark`       | CARTO Dark — English only                                                                        |
+| `Voyager`    | CARTO Voyager — English only                                                                     |
+| `Satellite`  | ESRI World Imagery — English only                                                                |
+| `OSM`        | OpenStreetMap — labels rendered in local language                                                |
+| `Grey`       | Esri Light Grey Canvas — English only, no CARTO key needed, free without signup                  |
+| `GreyDark`   | Esri Dark Grey Canvas — English only, no CARTO key needed, free without signup                   |
 
 When `map_style` is not set or set to `Auto`, the card picks Dark when the OS is in dark mode, `Light` for English-language instances in light mode, and `OSM` for all other languages in light mode. The map updates automatically if the OS theme changes.
+
+### CARTO API key
+
+CARTO's Light/Dark/Voyager tiles, and Satellite's label overlay, now stamp a visible "API key required" watermark on tiles fetched without a key — the tiles still load, just watermarked. A free key (no CARTO account needed — see [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey/), 5 million tile requests/month free) removes it. Set it in the editor's Map section, or via `carto_api_key` in YAML. Leaving it unset keeps today's watermarked-but-working tiles — never a hard error. Has no effect for `OSM`, `Grey`, or `GreyDark`, none of which use CARTO tiles.
 
 > **OpenStreetMap note:** OSM tiles are provided by the OpenStreetMap community. For high-traffic deployments please consider the [OSM tile usage policy](https://operations.osmfoundation.org/policies/tiles/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-radar-card",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-radar-card",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "type": "module",
   "description": "A rain radar card using data from RainViewer",
   "keywords": [

--- a/src/basemap-styles.ts
+++ b/src/basemap-styles.ts
@@ -1,0 +1,97 @@
+// Basemap tile URL templates per map_style, factored out of
+// weather-radar-card.ts so they're unit-testable without Leaflet/DOM.
+//
+// CARTO's free basemap tiles (Dark/Voyager/Light, and Satellite's label
+// overlay) now stamp anonymous requests with a visible "API key
+// required" watermark — the tiles still load, just watermarked. A free
+// key (carto.com/basemaps/apikey — no account needed) removes it via a
+// `?key=` query param. Grey/GreyDark are ESRI Living Atlas Canvas
+// basemaps that never need a key at all, for anyone who'd rather not
+// sign up — same free-for-public-apps basis this project already
+// relies on for Satellite's World_Imagery.
+
+const CARTO_HOST = 'https://{s}.basemaps.cartocdn.com';
+const ESRI_HOST = 'https://server.arcgisonline.com/ArcGIS/rest/services';
+
+function cartoTile(path: string, apiKey?: string): string {
+  const key = apiKey?.trim();
+  const suffix = key ? `?key=${encodeURIComponent(key)}` : '';
+  return `${CARTO_HOST}/${path}/{z}/{x}/{y}.png${suffix}`;
+}
+
+export interface BasemapTiles {
+  /** Leaflet {s}/{z}/{x}/{y} template for the base layer. */
+  url: string;
+  subdomains: string;
+  /** Empty when the base layer already carries labels (osm). */
+  labelUrl: string;
+  labelsBakedIn: boolean;
+}
+
+export function getBasemapTiles(mapStyle: string, cartoApiKey?: string): BasemapTiles {
+  switch (mapStyle) {
+    case 'dark':
+      return {
+        url: cartoTile('dark_nolabels', cartoApiKey),
+        subdomains: 'abcd',
+        labelUrl: cartoTile('dark_only_labels', cartoApiKey),
+        labelsBakedIn: false,
+      };
+    case 'voyager':
+      return {
+        url: cartoTile('rastertiles/voyager_nolabels', cartoApiKey),
+        subdomains: 'abcd',
+        labelUrl: cartoTile('rastertiles/voyager_only_labels', cartoApiKey),
+        labelsBakedIn: false,
+      };
+    case 'satellite':
+      return {
+        url: `${ESRI_HOST}/World_Imagery/MapServer/tile/{z}/{y}/{x}`,
+        subdomains: 'abcd',
+        labelUrl: cartoTile('rastertiles/voyager_only_labels', cartoApiKey),
+        labelsBakedIn: false,
+      };
+    case 'osm':
+      return {
+        url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        subdomains: 'abc',
+        labelUrl: '',
+        labelsBakedIn: true,
+      };
+    case 'grey':
+      return {
+        url: `${ESRI_HOST}/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}`,
+        subdomains: 'abcd',
+        labelUrl: `${ESRI_HOST}/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}`,
+        labelsBakedIn: false,
+      };
+    case 'greydark':
+      return {
+        url: `${ESRI_HOST}/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}`,
+        subdomains: 'abcd',
+        labelUrl: `${ESRI_HOST}/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}`,
+        labelsBakedIn: false,
+      };
+    default: // light / unset
+      return {
+        url: cartoTile('light_nolabels', cartoApiKey),
+        subdomains: 'abcd',
+        labelUrl: cartoTile('light_only_labels', cartoApiKey),
+        labelsBakedIn: false,
+      };
+  }
+}
+
+export type BasemapTone = 'light' | 'dark' | 'satellite';
+
+export function getBasemapTone(mapStyle: string | undefined): BasemapTone {
+  const s = mapStyle?.toLowerCase();
+  if (s === 'satellite') return 'satellite';
+  if (s === 'dark' || s === 'greydark') return 'dark';
+  return 'light';
+}
+
+/** True for any basemap dark enough to need light-on-dark UI colors. */
+export function isDarkBasemapStyle(mapStyle: string | undefined): boolean {
+  return getBasemapTone(mapStyle) !== 'light';
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -185,6 +185,8 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
                   { value: 'Dark', label: localize('editor.map.style_dark') },
                   { value: 'Satellite', label: localize('editor.map.style_satellite') },
                   { value: 'OSM', label: localize('editor.map.style_osm') },
+                  { value: 'Grey', label: localize('editor.map.style_grey') },
+                  { value: 'GreyDark', label: localize('editor.map.style_grey_dark') },
                 ],
               },
             }}
@@ -215,6 +217,28 @@ export class WeatherRadarCardEditor extends LitElement implements LovelaceCardEd
             @value-changed=${this._handleSelectorNumberChanged}
           ></ha-selector>
         </div>
+        ${(() => {
+          // CARTO key only does anything for the CARTO-backed styles
+          // (Light/Voyager/Dark/Satellite's label overlay) — hide it for
+          // OSM/Grey/GreyDark where it would be a no-op. Auto counts as
+          // "show it": Auto usually resolves to a CARTO-backed style, so
+          // hiding the field there would be wrong more often than not.
+          const style = (config.map_style || 'Auto').toLowerCase();
+          const cartoApplies = !['osm', 'grey', 'greydark'].includes(style);
+          return cartoApplies ? html`
+            <ha-input
+              label=${localize('editor.map.carto_api_key')}
+              type="password"
+              .value=${config.carto_api_key || ''}
+              .configValue=${'carto_api_key'}
+              @input=${this._valueChangedString}
+            ></ha-input>
+            <div class="section-description">
+              ${localize('editor.map.carto_api_key_helper')}
+              <a href="https://carto.com/basemaps/apikey/" target="_blank" rel="noopener noreferrer">${localize('editor.map.carto_api_key_link')}</a>
+            </div>
+          ` : '';
+        })()}
 
         <!-- LOCATION -->
         <h3 class="section-header">${localize('editor.section.location')}</h3>

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -88,6 +88,11 @@
       "style_dark": "CARTO Dark (English only)",
       "style_satellite": "Satellite (English only)",
       "style_osm": "OpenStreetMap (Localized)",
+      "style_grey": "Esri Grey Canvas (English only, no API key needed)",
+      "style_grey_dark": "Esri Grey Canvas Dark (English only, no API key needed)",
+      "carto_api_key": "CARTO API Key",
+      "carto_api_key_helper": "Optional. Removes CARTO's \"API key required\" watermark on Light/Voyager/Dark/Satellite tiles. Free, no CARTO account needed. Leave blank to keep today's (watermarked) tiles.",
+      "carto_api_key_link": "Get a free key",
       "zoom_level": "Zoom Level",
       "zoom_default": "Default (5)"
     },

--- a/src/marker-icon.ts
+++ b/src/marker-icon.ts
@@ -2,6 +2,7 @@ import * as L from 'leaflet';
 import { HomeAssistant } from 'custom-card-helpers';
 import { Marker } from './types';
 import { escapeHtml } from './string-utils';
+import { isDarkBasemapStyle } from './basemap-styles';
 
 const ICON_BASE = '/local/community/weather-radar-card/';
 
@@ -70,7 +71,7 @@ export function createMarkerIconForMarker(
   mapStyle: string,
 ): L.Icon | L.DivIcon {
   const iconType = markerCfg.icon || 'default';
-  const isDarkMap = mapStyle === 'dark' || mapStyle === 'satellite';
+  const isDarkMap = isDarkBasemapStyle(mapStyle);
   const svgFile = isDarkMap ? 'home-circle-light.svg' : 'home-circle-dark.svg';
   const defaultColour = isDarkMap ? '#EEEEEE' : '#333333';
   const colour = markerCfg.color ?? defaultColour;

--- a/src/radar-player.ts
+++ b/src/radar-player.ts
@@ -5,6 +5,7 @@ import { WeatherRadarCardConfig } from './types';
 import { Z_RADAR_BASE } from './const';
 import { RateLimiter } from './rate-limiter';
 import { FetchTileLayer, FetchWmsTileLayer, layerSettled } from './fetch-tile-layer';
+import { isDarkBasemapStyle } from './basemap-styles';
 import { RadarToolbar } from './radar-toolbar';
 import { localize } from './localize/localize';
 import { getEffectiveTimeRange } from './source-caps';
@@ -1639,8 +1640,7 @@ export class RadarPlayer {
       const override = isCurrent ? cfg.progress_bar_active_color : cfg.progress_bar_background_color;
       if (override) return override;
     }
-    const mapStyle = cfg.map_style?.toLowerCase() ?? '';
-    const dark = mapStyle === 'dark' || mapStyle === 'satellite';
+    const dark = isDarkBasemapStyle(cfg.map_style);
     const map = dark
       ? { empty: '#444', loading: '#aa7700', loaded: 'steelblue', failed: '#aa1111',
           cur_empty: '#666', cur_loading: '#cc9900', cur_loaded: '#6baed6', cur_failed: '#cc3333' }

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,17 @@ export interface WeatherRadarCardConfig extends LovelaceCardConfig {
   type: string;
   name?: string;
   map_style?: string;
+  /**
+   * Free CARTO API key (no account needed — carto.com/basemaps/apikey),
+   * appended as `?key=<value>` to CARTO basemap tile requests (the
+   * Light/Dark/Voyager base + label tiles, and Satellite's label
+   * overlay). CARTO's anonymous access still serves tiles without one,
+   * just stamped with a visible "API key required" watermark. Leaving
+   * this unset preserves that (watermarked but working) default — never
+   * a hard error. No effect for `map_style: OSM`, `Grey`, or `GreyDark`,
+   * none of which use CARTO tiles.
+   */
+  carto_api_key?: string;
   data_source?: string;
   /** DWD-only: ISO timestamp to anchor frames at instead of "now" — for testing with historical rain. */
   dwd_time_override?: string;

--- a/src/weather-radar-card.ts
+++ b/src/weather-radar-card.ts
@@ -16,6 +16,7 @@ import { getEffectiveTimeRange, shouldShowPlayback } from './source-caps';
 import { localize } from './localize/localize';
 import { rainviewerLimiter, noaaLimiter, dwdLimiter } from './rate-limiters';
 import { FetchTileLayer } from './fetch-tile-layer';
+import { getBasemapTiles, getBasemapTone, isDarkBasemapStyle } from './basemap-styles';
 import { WindOverlay } from './wind-overlay';
 import { defaultWindSourceForLocation, DEFAULT_WIND_SOURCE } from './wind-source-caps';
 import { WindFlowOverlay } from './wind-flow-overlay';
@@ -580,7 +581,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       `;
     }
     const mapStyle = this._effectiveMapStyle();
-    const isMapDark = mapStyle === 'dark' || mapStyle === 'satellite';
+    const isMapDark = isDarkBasemapStyle(mapStyle);
     const dataSource = this._config.data_source ?? 'RainViewer';
     const showColourBar = this._config.show_color_bar !== false;
     const progressBarTouchHeight = resolveProgressBarTouchHeight(this._config.progress_bar_touch_height);
@@ -824,34 +825,12 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     const cfg = this._config;
     const tileSize = cfg.extra_labels ? 128 : 256;
     const zoomOffset = cfg.extra_labels ? 1 : 0;
+    const { url, subdomains, labelUrl, labelsBakedIn } = getBasemapTiles(mapStyle, cfg.carto_api_key);
 
-    let url: string, style = '', subdomains = 'abcd', labelUrl = '', osmLabels = false;
-    switch (mapStyle) {
-      case 'dark':
-        url = 'https://{s}.basemaps.cartocdn.com/{style}/{z}/{x}/{y}.png';
-        style = 'dark_nolabels';
-        labelUrl = 'https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}.png'; break;
-      case 'voyager':
-        url = 'https://{s}.basemaps.cartocdn.com/{style}/{z}/{x}/{y}.png';
-        style = 'rastertiles/voyager_nolabels';
-        labelUrl = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}.png'; break;
-      case 'satellite':
-        url = 'https://server.arcgisonline.com/ArcGIS/rest/services/{style}/MapServer/tile/{z}/{y}/{x}';
-        style = 'World_Imagery';
-        labelUrl = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}.png'; break;
-      case 'osm':
-        osmLabels = true; subdomains = 'abc';
-        url = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'; break;
-      default:
-        url = 'https://{s}.basemaps.cartocdn.com/{style}/{z}/{x}/{y}.png';
-        style = 'light_nolabels';
-        labelUrl = 'https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png';
-    }
-
-    new FetchTileLayer(url, { style, subdomains, detectRetina: false, tileSize, zoomOffset } as any)
+    new FetchTileLayer(url, { subdomains, detectRetina: false, tileSize, zoomOffset } as any)
       .addTo(this._map).setZIndex(Z_BASEMAP);
 
-    if (!osmLabels && labelUrl) {
+    if (!labelsBakedIn && labelUrl) {
       this._townLayer = new FetchTileLayer(labelUrl, {
         subdomains: 'abcd', detectRetina: false, tileSize, zoomOffset,
       } as any).addTo(this._map);
@@ -900,10 +879,14 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       // theming or custom basemap palettes.
       let defaultColor: string;
       let customColor: string | undefined;
-      if (this._currentMapStyle === 'satellite') {
+      const tone = getBasemapTone(this._currentMapStyle ?? undefined);
+      if (tone === 'satellite') {
         defaultColor = 'rgba(255,255,255,1)';
         customColor = cfg.dwd_wind_flow_color_sat;
-      } else if (this._currentMapStyle === 'dark') {
+      } else if (tone === 'dark') {
+        // Reused for greydark too — near-white reads fine on both the
+        // dark Carto slate and ESRI's dark grey canvas; no separate
+        // override key needed for it.
         defaultColor = 'rgba(220,225,235,1)';
         customColor = cfg.dwd_wind_flow_color_dark;
       } else {
@@ -932,7 +915,9 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
       ? '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
       : mapStyle === 'satellite'
         ? '&copy; <a href="http://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9" target="_blank">ESRI</a>'
-        : '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> &copy; <a href="https://carto.com/attribution" target="_blank">CARTO</a>';
+        : mapStyle === 'grey' || mapStyle === 'greydark'
+          ? '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors &copy; <a href="https://www.esri.com" target="_blank">Esri</a>, HERE, Garmin'
+          : '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> &copy; <a href="https://carto.com/attribution" target="_blank">CARTO</a>';
     el.innerHTML = `<a href="https://leafletjs.com" target="_blank">Leaflet</a> | ${mapCredit} | ${radarCredit}`;
   }
 
@@ -1007,7 +992,7 @@ export class WeatherRadarCard extends LitElement implements LovelaceCard {
     this._trackedMarkerIdx = initialWinner?.markerIndex ?? -1;
 
     if (useClustering) {
-      const isDark = mapStyle === 'dark' || mapStyle === 'satellite';
+      const isDark = isDarkBasemapStyle(mapStyle);
       this._clusterGroup = L.markerClusterGroup({
         iconCreateFunction: (c) => this._createClusterIcon(c, isDark),
         maxClusterRadius: 60,

--- a/tests/basemap-styles.test.ts
+++ b/tests/basemap-styles.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { getBasemapTiles, getBasemapTone, isDarkBasemapStyle } from '../src/basemap-styles';
+
+describe('getBasemapTiles', () => {
+  it('CARTO styles omit ?key= entirely when no API key is set (today\'s default)', () => {
+    expect(getBasemapTiles('dark').url).toBe('https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png');
+    expect(getBasemapTiles('dark').labelUrl).toBe('https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}.png');
+    expect(getBasemapTiles('voyager').url)
+      .toBe('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png');
+    expect(getBasemapTiles('unknown-or-unset').url)
+      .toBe('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png');
+  });
+
+  it('appends ?key=<value> to every CARTO URL when a key is set', () => {
+    const t = getBasemapTiles('dark', 'abc123');
+    expect(t.url).toBe('https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png?key=abc123');
+    expect(t.labelUrl).toBe('https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}.png?key=abc123');
+  });
+
+  it('URI-encodes special characters in the key', () => {
+    const t = getBasemapTiles('voyager', 'a b/c');
+    expect(t.url).toContain(`?key=${encodeURIComponent('a b/c')}`);
+  });
+
+  it('trims a whitespace-padded key and treats an all-whitespace key as unset', () => {
+    expect(getBasemapTiles('dark', '  abc123  ').url).toContain('?key=abc123');
+    expect(getBasemapTiles('dark', '   ').url).not.toContain('?key=');
+  });
+
+  it('satellite: ESRI imagery base is never affected by the key, but its CARTO label overlay is', () => {
+    const withKey = getBasemapTiles('satellite', 'abc123');
+    expect(withKey.url).toBe('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}');
+    expect(withKey.labelUrl).toContain('?key=abc123');
+    const noKey = getBasemapTiles('satellite');
+    expect(noKey.url).toBe(withKey.url);
+    expect(noKey.labelUrl).not.toContain('?key=');
+  });
+
+  it('osm: no key ever affects it, and labels are baked into the base layer', () => {
+    const t = getBasemapTiles('osm', 'abc123');
+    expect(t.url).toBe('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+    expect(t.labelUrl).toBe('');
+    expect(t.labelsBakedIn).toBe(true);
+    expect(t.url).not.toContain('key=');
+  });
+
+  it('grey/greydark: ESRI canvas tiles, never affected by a CARTO key, need no key at all', () => {
+    const grey = getBasemapTiles('grey', 'abc123');
+    expect(grey.url).toBe('https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}');
+    expect(grey.labelUrl).toBe('https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}');
+    expect(grey.labelsBakedIn).toBe(false);
+
+    const greyDark = getBasemapTiles('greydark', 'abc123');
+    expect(greyDark.url).toBe('https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}');
+    expect(greyDark.labelUrl).toBe('https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}');
+  });
+});
+
+describe('getBasemapTone / isDarkBasemapStyle', () => {
+  it('classifies each style correctly', () => {
+    expect(getBasemapTone('dark')).toBe('dark');
+    expect(getBasemapTone('greydark')).toBe('dark');
+    expect(getBasemapTone('satellite')).toBe('satellite');
+    expect(getBasemapTone('light')).toBe('light');
+    expect(getBasemapTone('voyager')).toBe('light');
+    expect(getBasemapTone('osm')).toBe('light');
+    expect(getBasemapTone('grey')).toBe('light');
+    expect(getBasemapTone(undefined)).toBe('light');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getBasemapTone('Dark')).toBe('dark');
+    expect(getBasemapTone('GreyDark')).toBe('dark');
+  });
+
+  it('isDarkBasemapStyle is true for dark and satellite tones only', () => {
+    expect(isDarkBasemapStyle('dark')).toBe(true);
+    expect(isDarkBasemapStyle('satellite')).toBe(true);
+    expect(isDarkBasemapStyle('greydark')).toBe(true);
+    expect(isDarkBasemapStyle('grey')).toBe(false);
+    expect(isDarkBasemapStyle('osm')).toBe(false);
+    expect(isDarkBasemapStyle(undefined)).toBe(false);
+  });
+});

--- a/tests/marker-icon.test.ts
+++ b/tests/marker-icon.test.ts
@@ -37,6 +37,13 @@ describe('createMarkerIconForMarker', () => {
     expect(result.iconUrl).toContain('home-circle-light.svg');
   });
 
+  it('uses light SVG on greydark map style, dark SVG on grey', () => {
+    const dark = createMarkerIconForMarker({ icon: 'default' }, mockHass(), 'greydark') as any;
+    expect(dark.iconUrl).toContain('home-circle-light.svg');
+    const grey = createMarkerIconForMarker({ icon: 'default' }, mockHass(), 'grey') as any;
+    expect(grey.iconUrl).toContain('home-circle-dark.svg');
+  });
+
   it('returns entity_picture icon when entity has a picture URL', () => {
     const hass = mockHass({
       states: {

--- a/tests/radar-player-progress-bar-colors.test.ts
+++ b/tests/radar-player-progress-bar-colors.test.ts
@@ -58,6 +58,17 @@ describe('_segColor — progress_bar_background_color / progress_bar_active_colo
     expect(p._segColor('loaded', true)).toBe('#66d9ff');
   });
 
+  it('greydark map_style gets the dark palette, same as dark/satellite', () => {
+    const p = makePlayer({ map_style: 'greydark' }) as any;
+    expect(p._segColor('empty', false)).toBe('#444');
+    expect(p._segColor('loaded', true)).toBe('#6baed6');
+  });
+
+  it('grey map_style gets the light palette', () => {
+    const p = makePlayer({ map_style: 'grey' }) as any;
+    expect(p._segColor('empty', false)).toBe('#e0e0e0');
+  });
+
   it('progress_bar_background_color overrides non-current empty/loaded segments', () => {
     const p = makePlayer({ progress_bar_background_color: '#123456' }) as any;
     expect(p._segColor('empty', false)).toBe('#123456');


### PR DESCRIPTION
## Summary
- CARTO began requiring an API key to avoid a visible "API key required" watermark on their free basemap tiles (Light/Voyager/Dark/Satellite) — anonymous access still works, just watermarked. Adds a `carto_api_key` config option (editor-exposed, Map section) to remove it.
- Adds two new no-key `map_style` options, `Grey`/`GreyDark` (Esri Light/Dark Grey Canvas), for anyone who'd rather not sign up for a CARTO key at all.
- Centralizes the "is this basemap dark" check (previously duplicated in 4 places) into a shared `basemap-styles.ts` helper, since the new `GreyDark` style needed to be recognized as dark by markers, cluster icons, the scale-line, the progress bar palette, and the wind-streamline color.
- Live-verified in the local HA testbed: CARTO watermark disappears with a real key, Grey/GreyDark render with no key, the editor field shows/hides correctly per style, and the password field masks correctly.

## Test plan
- [x] `npm test` (748 tests, incl. 10 new for `basemap-styles.ts` plus extended marker-icon/progress-bar-color cases)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manually verified in the local HA testbed (see above)