### PR TITLE
docs(templates): tell bug reporters to redact carto_api_key too

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,7 +45,8 @@ editor" (toggle in the top-right of the card editor) -> copy everything
 and paste it below, between the ```yaml and ``` lines (this is what
 makes it render as a readable code block instead of one long line).
 Please redact your exact location — trimming the last digit or two off
-your latitude/longitude is enough.
+your latitude/longitude is enough — and remove any carto_api_key value
+before posting.
 -->
 
 ```yaml


### PR DESCRIPTION
## Summary
- The bug report template's config-redaction note only mentioned lat/long — `carto_api_key` didn't exist when it was written. Extends it to cover the new field.